### PR TITLE
feat: NumPy integration — unit-carrying arrays (NEP 13/18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,19 @@ jobs:
       - name: Run tests
         run: pixi run -e ${{ matrix.environment }} test
 
+  test-np126:
+    name: Test with NumPy 1.26 (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.72.0
+          environments: test-np126
+          cache: true
+      - name: Run tests against NumPy 1.26
+        run: pixi run -e test-np126 test
+
   test-jax:
     name: Test with JAX (ubuntu-latest)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     and much more.
   - Fail-loud everywhere: any uncovered ufunc/function, any `out=` argument, and
     `multiply.reduce` raise `UnsupportedOperationError` naming the operation;
-    units are never silently dropped. `np.array(q)`/`np.asarray(q)` and
-    `float(q)`/`int(q)`/`complex(q)` raise with guidance to use `duq.ustrip`,
-    closing the classic silent-strip hole.
+    units are never silently dropped. `np.array(q)`/`np.asarray(q)` raise with
+    guidance to use `duq.ustrip`, closing the classic silent-strip hole.
+    `float(q)`/`int(q)`/`complex(q)`/`bool(q)` coerce **dimensionless**
+    quantities by applying the unit scale (`float(Quantity(50.0, "%")) == 0.5`;
+    radian-labelled values pass through) and raise for anything dimensional —
+    pint-consistent behaviour.
   - `Unit` opts out of NumPy's ufunc machinery (`__array_ufunc__ = None`) and
     scales into a `Quantity` when combined with a number or array, so
     `np.linspace(0, 1, 5) * duq.units.m`, `5 * duq.units.m`, `duq.units.m * 5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **NumPy integration — unit-carrying arrays (NEP 13 / NEP 18):**
+  - The existing `Quantity` now also wraps a NumPy array (or NumPy scalar) as its
+    magnitude (`Quantity(np.array(...), unit)`, or `Quantity.from_array([...],
+    unit)` for lists); the array is stored as-is, with no copy.
+  - `Quantity.__array_ufunc__` and `__array_function__` carry units through a
+    curated ufunc table (~70 ufuncs) and function table (~130 functions), driven
+    by the shared `duq._rules` engine: `multiply`/`matmul`→product,
+    `divide`/`floor_divide`→quotient, `add`/`subtract`/`hypot`/`maximum`/… →
+    same-dimension (right operand converted to the left unit), `power`/`sqrt`/
+    `cbrt`/`square`/`reciprocal`→unit powers, `exp`/`log`/trig→dimensionless
+    (angle and `%` rescaled), inverse trig→radian-labelled, comparisons→plain
+    bool arrays, `var`→unit², `gradient`/`trapezoid`→unit division/multiplication,
+    and much more.
+  - Fail-loud everywhere: any uncovered ufunc/function, any `out=` argument, and
+    `multiply.reduce` raise `UnsupportedOperationError` naming the operation;
+    units are never silently dropped. `np.array(q)`/`np.asarray(q)` and
+    `float(q)`/`int(q)`/`complex(q)` raise with guidance to use `duq.ustrip`,
+    closing the classic silent-strip hole.
+  - `Unit` opts out of NumPy's ufunc machinery (`__array_ufunc__ = None`) and
+    scales into a `Quantity` when combined with a number or array, so
+    `np.linspace(0, 1, 5) * duq.units.m`, `5 * duq.units.m`, `duq.units.m * 5`
+    and `array / unit` all yield a `Quantity` (`1 / unit` still inverts the unit).
+  - Array `Quantity` gains `.shape`/`.ndim`/`.size`/`.dtype`/`.T`, `len()`,
+    iteration and indexing (yielding element quantities), `.item()`, and thin
+    `.sum()/.mean()/.std()/.var()/.min()/.max()/.reshape()/.ravel()/.astype()`
+    delegates that route through the same unit rules.
+  - New `duq._numpy` back-end package, imported lazily only from the array hooks,
+    so `import duq` and all scalar arithmetic remain NumPy-free (asserted by CI).
+  - A pixi `test-np126` environment (Python 3.11, NumPy 1.26) plus an Ubuntu CI
+    job guard the NumPy 1.26 ↔ 2.x differences (including the `trapz`/`trapezoid`
+    rename).
 - Complete rewrite of the core as a pure-Python, array-free layer:
   - `Dimension`: an immutable, hashable vector of exact `Fraction` exponents
     over the seven SI base dimensions, with `*`/`/`/`**` algebra and a

--- a/pixi.lock
+++ b/pixi.lock
@@ -683,6 +683,188 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - pypi: ./
+  test-np126:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py311h3778330_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hypothesis-6.156.3-py311h902ca64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - pypi: ./
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.15.0-py311ha8ae342_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hypothesis-6.156.3-py311h3a14e8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.3-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.15-ha9537fe_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - pypi: ./
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.15.0-py311hc290fe0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hypothesis-6.156.3-py311hf7c400d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h0c9c016_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - pypi: ./
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.15.0-py311h3f79411_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hypothesis-6.156.3-py311hf51aa87_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-8_h2a3cdd5_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-8_hf9ab0e9_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.3-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.3-h692994f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.3-hbc0d294_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.8-h4fa8253_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.15-h0159041_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+      - pypi: ./
   test-py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2202,6 +2384,19 @@ packages:
   run_exports: {}
   size: 5852044
   timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+  sha256: 0672b6b6e1791c92e8eccad58081a99d614fcf82bca5841f9dfa3c3e658f83b9
+  md5: e5ce228e579726c07255dbf90dc62101
+  depends:
+  - libstdcxx 15.2.0 h934c35e_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - libstdcxx
+  size: 27776
+  timestamp: 1778269074600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
   sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
   md5: 01bb81d12c957de066ea7362007df642
@@ -2290,6 +2485,28 @@ packages:
     - ncurses >=6.6,<7.0a0
   size: 918956
   timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+  sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
+  md5: a502d7aad449a1206efb366d6a12c52d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  run_exports:
+    weak:
+    - numpy >=1.26.4,<2.0a0
+  size: 8065890
+  timestamp: 1707225944355
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py311h2e04523_0.conda
   sha256: 8e8fb64c1a51282e8940d57d116aec54a4d66da59594973ae9c0b35d419b9a81
   md5: 5d4e35d7097b88c8b1455ef9f6ddf511
@@ -3833,6 +4050,27 @@ packages:
     - ncurses >=6.6,<7.0a0
   size: 831711
   timestamp: 1777423052277
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+  sha256: dc9628197125ee1d02b2e7a859a769d26291d747ed79337309b8a9e67a8b8e00
+  md5: bb02b8801d17265160e466cf8bbf28da
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  run_exports:
+    weak:
+    - numpy >=1.26.4,<2.0a0
+  size: 7504319
+  timestamp: 1707226235372
 - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py311h2c4eb96_0.conda
   sha256: 47fa3ad9a49348efb5662d7850a433607ee4fabf259709731437a969c3006fa9
   md5: 0cb49ff5e81a76c101f1a561cf1f2a76
@@ -4794,6 +5032,28 @@ packages:
     - ncurses >=6.6,<7.0a0
   size: 805509
   timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+  sha256: 160a52a01fea44fe9753a2ed22cf13d7b55c8a89ea0b8738546fdbf4795d6514
+  md5: 3160b93669a0def35a7a8158ebb33816
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  run_exports:
+    weak:
+    - numpy >=1.26.4,<2.0a0
+  size: 6652352
+  timestamp: 1707226297967
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py311hbd1492f_0.conda
   sha256: 08e5062ab9bce23adef1c62282a99d035780e43eb8a843b0f11d8a1e967fe123
   md5: 7738446d4be7ac8b56e6d6e3bdb7e52b
@@ -5619,6 +5879,29 @@ packages:
   run_exports: {}
   size: 10675706
   timestamp: 1783529686555
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+  sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
+  md5: 7b240edd44fd7a0991aa409b07cee776
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  run_exports:
+    weak:
+    - numpy >=1.26.4,<2.0a0
+  size: 7104093
+  timestamp: 1707226459646
 - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py311h65cb7f3_0.conda
   sha256: cd26f615140d0ed557f8927947ca62c181d55ddbe418eebd24bd06cd32fb3938
   md5: ef5c1dedd943abfb0b80112ba46d4ab8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ platforms = ["osx-64", "osx-arm64", "linux-64"]
 [tool.pixi.feature.jax.dependencies]
 jax = ">=0.5"
 
+# NumPy 1.26 pin: guards the NEP-13/18 behaviour differences (and the
+# trapz/trapezoid rename) between NumPy 1.26 and 2.x on the minimum Python.
+[tool.pixi.feature.np126.dependencies]
+python = "3.11.*"
+numpy = "1.26.*"
+
 # Python-version pin features for the test matrix.
 [tool.pixi.feature.py311.dependencies]
 python = "3.11.*"
@@ -126,6 +132,7 @@ test-jax = { features = ["test", "jax"] }
 lint = { features = ["lint"], no-default-feature = true }
 # Type-check against the minimum supported Python (matches mypy's python_version).
 type = { features = ["type", "py311"], no-default-feature = true }
+test-np126 = { features = ["test", "np126"] }
 test-py311 = { features = ["test", "py311"] }
 test-py312 = { features = ["test", "py312"] }
 test-py313 = { features = ["test", "py313"] }
@@ -167,6 +174,15 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D", "PL"]
+# The NumPy back-end is imported lazily throughout these two modules (inside the
+# array hooks and array helpers) so that the pure core never imports NumPy;
+# PLC0415 (import-not-at-top-level) is the intended pattern here, not a smell.
+"src/duq/_quantity.py" = ["PLC0415"]
+"src/duq/_unit.py" = ["PLC0415"]
+# The __array_function__ handlers branch on NumPy positional-argument counts
+# (``len(args) > 2`` etc.); those small integers are argument positions, not
+# magic domain constants, so PLR2004 is noise here.
+"src/duq/_numpy/_functions.py" = ["PLR2004"]
 
 # ---------------------------------------------------------------------------
 # mypy

--- a/src/duq/_arraytypes.py
+++ b/src/duq/_arraytypes.py
@@ -1,0 +1,70 @@
+"""Lazy NumPy type detection that never imports NumPy itself.
+
+The helpers here answer "is this object a NumPy array or scalar?" by consulting
+:data:`sys.modules`.  If NumPy has never been imported then nothing in the
+process can be a NumPy object, so the answer is trivially ``False`` and
+``import duq`` -- together with all scalar arithmetic -- stays NumPy-free.  The
+moment a genuine array appears, NumPy is guaranteed to already be in
+``sys.modules`` (the caller had to import it to build the array), so the check
+is both correct and free of an eager import.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+__all__ = (
+    "is_numpy_array",
+    "is_numpy_magnitude",
+    "numpy_if_loaded",
+)
+
+
+def numpy_if_loaded() -> ModuleType | None:
+    """Return the already-imported ``numpy`` module, or ``None``.
+
+    Returns
+    -------
+    module or None
+        The :mod:`numpy` module if it has been imported, else ``None``.
+    """
+    return sys.modules.get("numpy")
+
+
+def is_numpy_array(value: object) -> bool:
+    """Return whether ``value`` is a NumPy ``ndarray`` without importing NumPy.
+
+    Parameters
+    ----------
+    value : object
+        The object to test.
+
+    Returns
+    -------
+    bool
+        ``True`` only if NumPy is imported and ``value`` is an ``ndarray``.
+    """
+    np = sys.modules.get("numpy")
+    return np is not None and isinstance(value, np.ndarray)
+
+
+def is_numpy_magnitude(value: object) -> bool:
+    """Return whether ``value`` is a NumPy array or scalar without importing NumPy.
+
+    Parameters
+    ----------
+    value : object
+        The object to test.
+
+    Returns
+    -------
+    bool
+        ``True`` only if NumPy is imported and ``value`` is an ``ndarray`` or a
+        NumPy scalar (``numpy.generic``).
+    """
+    np = sys.modules.get("numpy")
+    return np is not None and isinstance(value, np.ndarray | np.generic)

--- a/src/duq/_numpy/__init__.py
+++ b/src/duq/_numpy/__init__.py
@@ -1,0 +1,49 @@
+"""NumPy back-end for :class:`duq.Quantity` (NEP 13 / NEP 18).
+
+This package is imported *lazily* -- only from ``Quantity``'s array hooks and
+array helpers -- so ``import duq`` and all scalar arithmetic stay NumPy-free.
+It carries units through the curated ufunc and function tables, driven by the
+core :mod:`duq._rules` engine, and fails loud on anything uncovered.
+"""
+
+from __future__ import annotations
+
+from ._dispatch import (
+    dispatch_function,
+    dispatch_ufunc,
+    get_item,
+    iter_quantity,
+    magnitude_dtype,
+    magnitude_len,
+    magnitude_ndim,
+    magnitude_shape,
+    magnitude_size,
+    matmul,
+    q_astype,
+    q_ravel,
+    q_reduce,
+    q_reshape,
+    q_transpose,
+    richcompare,
+    scalar_item,
+)
+
+__all__ = (
+    "dispatch_function",
+    "dispatch_ufunc",
+    "get_item",
+    "iter_quantity",
+    "magnitude_dtype",
+    "magnitude_len",
+    "magnitude_ndim",
+    "magnitude_shape",
+    "magnitude_size",
+    "matmul",
+    "q_astype",
+    "q_ravel",
+    "q_reduce",
+    "q_reshape",
+    "q_transpose",
+    "richcompare",
+    "scalar_item",
+)

--- a/src/duq/_numpy/_common.py
+++ b/src/duq/_numpy/_common.py
@@ -1,0 +1,210 @@
+"""Shared primitives for the NumPy front-end.
+
+Importing this module imports NumPy, so it is only ever reached lazily from
+:class:`duq.Quantity`'s array hooks.  Everything here is small and pure: unit
+resolution, magnitude conversion, dimensionless/angle stripping and result
+boxing, on top of the core :mod:`duq._rules` engine.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from duq._dimension import Dimension, _coerce_exponent
+from duq._errors import AffineUnitError, DimensionalityError, UnsupportedOperationError
+from duq._quantity import Quantity
+from duq._rules import Rule, apply
+from duq._unit import Unit
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from duq._registry import UnitRegistry
+
+__all__ = (
+    "Quantity",
+    "Unit",
+    "all_false",
+    "all_true",
+    "box",
+    "compare_core",
+    "convert_magnitude",
+    "dimensionless_unit",
+    "find_quantity",
+    "magnitude",
+    "registry_of",
+    "reject_affine",
+    "require_dimensionless_raw",
+    "to_pure",
+    "to_unit",
+    "unit_of",
+)
+
+_DIMENSIONLESS = Dimension({})
+
+_COMPARE_UFUNCS: dict[str, Any] = {
+    "equal": np.equal,
+    "not_equal": np.not_equal,
+    "less": np.less,
+    "less_equal": np.less_equal,
+    "greater": np.greater,
+    "greater_equal": np.greater_equal,
+}
+
+
+def magnitude(x: object) -> Any:
+    """Return the raw magnitude of a Quantity, or ``x`` unchanged."""
+    return x.value if isinstance(x, Quantity) else x
+
+
+def unit_of(x: object) -> Unit | None:
+    """Return the unit of a Quantity, or ``None`` for a plain operand."""
+    return x.unit if isinstance(x, Quantity) else None
+
+
+def dimension_of(x: object) -> Dimension:
+    """Return the dimension of a Quantity, or dimensionless for a plain operand."""
+    return x.dimension if isinstance(x, Quantity) else _DIMENSIONLESS
+
+
+def find_quantity(obj: object) -> Quantity | None:
+    """Return the first Quantity in ``obj`` (searching one level into sequences)."""
+    if isinstance(obj, Quantity):
+        return obj
+    if isinstance(obj, list | tuple):
+        for item in obj:
+            if isinstance(item, Quantity):
+                return item
+    return None
+
+
+def registry_of(*objs: object) -> UnitRegistry:
+    """Return the registry of the first Quantity found among ``objs``."""
+    for obj in objs:
+        found = find_quantity(obj)
+        if found is not None:
+            return found.unit.registry
+    raise UnsupportedOperationError("expected at least one duq.Quantity operand")
+
+
+def dimensionless_unit(registry: UnitRegistry) -> Unit:
+    """Return the registry's bare dimensionless unit (``"1"``)."""
+    return registry.unit("1")
+
+
+def box(mag: object, unit: Unit) -> Quantity:
+    """Wrap a magnitude in a :class:`Quantity` with ``unit``."""
+    return Quantity(mag, unit)  # type: ignore[arg-type]
+
+
+def reject_affine(*units: Unit | None, action: str = "scale") -> None:
+    """Raise :class:`AffineUnitError` if any of ``units`` is affine (e.g. ``°C``)."""
+    for unit in units:
+        if unit is not None and unit.is_affine:
+            raise AffineUnitError(f"cannot {action} an affine quantity such as °C or °F")
+
+
+def convert_magnitude(mag: Any, src: Unit, tgt: Unit) -> Any:
+    """Convert a bare magnitude from ``src`` to ``tgt`` using float scale/offset."""
+    if src.scale == tgt.scale and src.offset == tgt.offset:
+        return mag
+    s, s_off = float(src.scale), float(src.offset)
+    t, t_off = float(tgt.scale), float(tgt.offset)
+    return (mag * s + s_off - t_off) / t
+
+
+def to_unit(x: object, unit: Unit) -> Any:
+    """Convert operand ``x`` to ``unit`` and return its bare magnitude.
+
+    A plain (unitless) operand is accepted only when ``unit`` is dimensionless;
+    a Quantity of an incompatible dimension raises :class:`DimensionalityError`.
+    """
+    if isinstance(x, Quantity):
+        apply(Rule.SAME_DIM, x.dimension, unit.dimension)
+        return convert_magnitude(x.value, x.unit, unit)
+    if not unit.is_dimensionless:
+        raise DimensionalityError(
+            f"cannot combine a bare array/number with a quantity of dimension {unit.dimension}"
+        )
+    return x
+
+
+def to_pure(x: object) -> Any:
+    """Return the plain dimensionless value of ``x`` (``%`` and ``deg`` rescaled).
+
+    A dimensionless (or angle) Quantity is stripped after multiplying by its
+    scale, so ``50 %`` becomes ``0.5`` and ``90 deg`` becomes ``pi/2``.
+    """
+    if isinstance(x, Quantity):
+        u = x.unit
+        if not u.is_dimensionless:
+            raise DimensionalityError(
+                f"expected a dimensionless or angle operand, got dimension {u.dimension}"
+            )
+        mag: Any = x.value
+        return mag * float(u.scale)
+    return x
+
+
+def require_dimensionless_raw(x: object) -> Any:
+    """Return the raw magnitude of ``x``, requiring a dimensionless operand.
+
+    Unlike :func:`to_pure` the scale is *not* applied; this suits the angle
+    conversion ufuncs (``deg2rad``/``rad2deg``) which do the scaling themselves.
+    """
+    if isinstance(x, Quantity):
+        if not x.unit.is_dimensionless:
+            raise DimensionalityError(
+                f"expected a dimensionless operand, got dimension {x.unit.dimension}"
+            )
+        return x.value
+    return x
+
+
+def _broadcast_shape(a: object, b: object) -> tuple[int, ...]:
+    return np.broadcast_shapes(np.shape(magnitude(a)), np.shape(magnitude(b)))
+
+
+def all_false(a: object, b: object) -> Any:
+    """Return a broadcast ``bool`` array of ``False`` (incompatible ``equal``)."""
+    return np.zeros(_broadcast_shape(a, b), dtype=bool)
+
+
+def all_true(a: object, b: object) -> Any:
+    """Return a broadcast ``bool`` array of ``True`` (incompatible ``not_equal``)."""
+    return np.ones(_broadcast_shape(a, b), dtype=bool)
+
+
+def compare_core(op_name: str, a: object, b: object) -> Any:
+    """Compare two operands unit-aware, returning a plain ``bool`` ndarray.
+
+    ``equal``/``not_equal`` on incompatible dimensions short-circuit to an
+    all-``False``/all-``True`` array (parity with the scalar ``==`` policy);
+    ordering on incompatible dimensions raises :class:`DimensionalityError`.
+    """
+    da, db = dimension_of(a), dimension_of(b)
+    if da != db:
+        if op_name == "equal":
+            return all_false(a, b)
+        if op_name == "not_equal":
+            return all_true(a, b)
+        raise DimensionalityError(f"cannot order-compare quantities of dimension {da} and {db}")
+    ua, ub = unit_of(a), unit_of(b)
+    reference = ua if ua is not None else ub
+    if reference is None:  # pragma: no cover - dispatch guarantees a Quantity operand
+        raise UnsupportedOperationError("expected at least one duq.Quantity operand")
+    ma = to_unit(a, reference)
+    mb = to_unit(b, reference)
+    return _COMPARE_UFUNCS[op_name](ma, mb)
+
+
+def convert_sequence(items: Sequence[object], unit: Unit) -> list[Any]:
+    """Convert every operand in ``items`` to ``unit`` (for concatenate/stack)."""
+    return [to_unit(item, unit) for item in items]
+
+
+def unit_power(unit: Unit, exponent: object) -> Unit:
+    """Raise ``unit`` to an exact ``exponent`` (coercing floats such as ``0.5``)."""
+    return unit ** _coerce_exponent(exponent)

--- a/src/duq/_numpy/_dispatch.py
+++ b/src/duq/_numpy/_dispatch.py
@@ -1,0 +1,198 @@
+"""Entry points wired into :class:`duq.Quantity`'s NumPy hooks.
+
+These functions are imported lazily from the ``Quantity.__array_*`` methods and
+its array introspection/reduction helpers; they route each call to the curated
+:data:`~duq._numpy._ufuncs.UFUNC_TABLE` / :data:`~duq._numpy._functions.FUNCTION_TABLE`
+and fail loud (``UnsupportedOperationError``) on anything uncovered.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from duq._errors import UnsupportedOperationError
+
+from ._common import Quantity, box, compare_core, magnitude, unit_of
+from ._functions import FUNCTION_TABLE
+from ._ufuncs import REDUCE_PRESERVE, UFUNC_TABLE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy.typing as npt
+
+__all__ = (
+    "dispatch_function",
+    "dispatch_ufunc",
+    "get_item",
+    "iter_quantity",
+    "magnitude_dtype",
+    "magnitude_len",
+    "magnitude_ndim",
+    "magnitude_shape",
+    "magnitude_size",
+    "matmul",
+    "q_astype",
+    "q_ravel",
+    "q_reduce",
+    "q_reshape",
+    "q_transpose",
+    "richcompare",
+    "scalar_item",
+)
+
+
+# -- protocol dispatch -------------------------------------------------------
+
+
+def _name(ufunc: Any) -> str:
+    return str(getattr(ufunc, "__name__", ufunc))
+
+
+def dispatch_ufunc(
+    ufunc: Any, method: str, inputs: tuple[object, ...], kwargs: dict[str, Any]
+) -> object:
+    """Route a NumPy ufunc call through the curated unit-rule table."""
+    if kwargs.get("out") is not None:
+        raise UnsupportedOperationError(
+            "a Quantity is immutable, so the ufunc out= argument is not supported"
+        )
+    call_kwargs = {key: value for key, value in kwargs.items() if key != "out"}
+    if method == "__call__":
+        handler = UFUNC_TABLE.get(ufunc)
+        if handler is None:
+            raise UnsupportedOperationError(
+                f"the numpy ufunc {_name(ufunc)!r} has no duq unit rule and is unsupported"
+            )
+        return handler(ufunc, inputs, call_kwargs)
+    if method in ("reduce", "accumulate"):
+        return _reduce(ufunc, method, inputs, call_kwargs)
+    raise UnsupportedOperationError(
+        f"the ufunc method {_name(ufunc)}.{method} is not supported by duq"
+    )
+
+
+def _reduce(ufunc: Any, method: str, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    if ufunc in REDUCE_PRESERVE:
+        operand = inputs[0]
+        result = getattr(ufunc, method)(magnitude(operand), **kwargs)
+        unit = unit_of(operand)
+        return box(result, unit) if unit is not None else result
+    if ufunc is np.multiply:
+        raise UnsupportedOperationError(
+            "multiply.reduce is unsupported: it would raise the unit to the array "
+            "length (an ambiguous unit**n); duq ships no .prod() equivalent in v1"
+        )
+    raise UnsupportedOperationError(
+        f"the ufunc reduction {_name(ufunc)}.{method} is not supported by duq"
+    )
+
+
+def dispatch_function(
+    func: Callable[..., object],
+    types: object,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> object:
+    """Route a NumPy function call through the curated unit-rule table."""
+    handler = FUNCTION_TABLE.get(func)
+    if handler is None:
+        module = getattr(func, "__module__", "numpy")
+        name = getattr(func, "__name__", repr(func))
+        raise UnsupportedOperationError(
+            f"the numpy function {module}.{name} has no duq unit rule and is "
+            "unsupported; call duq.ustrip(unit, q) to drop units explicitly first"
+        )
+    return handler(args, dict(kwargs))
+
+
+def richcompare(op_name: str, left: object, right: object) -> npt.NDArray[Any]:
+    """Compare two operands (at least one array), returning a plain bool ndarray."""
+    return cast("npt.NDArray[Any]", compare_core(op_name, left, right))
+
+
+def matmul(a: Any, b: Any) -> object:
+    """Matrix-multiply two operands (``@``), multiplying their units."""
+    return np.matmul(a, b)
+
+
+# -- array introspection -----------------------------------------------------
+
+
+def magnitude_shape(mag: Any) -> tuple[int, ...]:
+    """Return the shape of a magnitude (``()`` for a scalar)."""
+    return np.shape(mag)
+
+
+def magnitude_ndim(mag: Any) -> int:
+    """Return the number of dimensions of a magnitude."""
+    return int(np.ndim(mag))
+
+
+def magnitude_size(mag: Any) -> int:
+    """Return the number of elements in a magnitude."""
+    return int(np.size(mag))
+
+
+def magnitude_dtype(mag: Any) -> np.dtype[Any]:
+    """Return the NumPy dtype of a magnitude."""
+    return np.asarray(mag).dtype
+
+
+def magnitude_len(mag: Any) -> int:
+    """Return ``len`` of an array magnitude (raises for a scalar magnitude)."""
+    return len(mag)
+
+
+def iter_quantity(q: Quantity) -> Iterator[Quantity]:
+    """Iterate an array quantity, yielding element quantities (unit preserved)."""
+    mag: Any = q.value
+    return (Quantity(element, q.unit) for element in mag)
+
+
+def get_item(q: Quantity, key: object) -> Quantity:
+    """Index an array quantity, returning a quantity (unit preserved)."""
+    mag: Any = q.value
+    return Quantity(mag[key], q.unit)
+
+
+def scalar_item(q: Quantity, args: tuple[Any, ...]) -> Quantity:
+    """Return a single element as a scalar quantity (unit preserved)."""
+    mag = np.asarray(q.value)
+    return Quantity(mag.item(*args), q.unit)
+
+
+# -- array reductions / reshaping --------------------------------------------
+
+
+def q_transpose(q: Quantity) -> Quantity:
+    """Transpose an array quantity (unit preserved)."""
+    return Quantity(np.asarray(q.value).T, q.unit)
+
+
+def q_reduce(q: Quantity, name: str, kwargs: dict[str, Any], unit_power: int = 1) -> Quantity:
+    """Reduce a quantity with ``numpy.<name>`` (unit raised to ``unit_power``)."""
+    func = getattr(np, name)
+    result = func(q.value, **kwargs)
+    unit = q.unit if unit_power == 1 else q.unit**unit_power
+    return Quantity(result, unit)
+
+
+def q_reshape(q: Quantity, shape: tuple[Any, ...], kwargs: dict[str, Any]) -> Quantity:
+    """Reshape an array quantity (unit preserved)."""
+    mag = np.asarray(q.value)
+    return Quantity(mag.reshape(*shape, **kwargs), q.unit)
+
+
+def q_ravel(q: Quantity, kwargs: dict[str, Any]) -> Quantity:
+    """Flatten an array quantity (unit preserved)."""
+    mag = np.asarray(q.value)
+    return Quantity(mag.ravel(**kwargs), q.unit)
+
+
+def q_astype(q: Quantity, dtype: Any, kwargs: dict[str, Any]) -> Quantity:
+    """Cast an array quantity's dtype (unit preserved)."""
+    mag = np.asarray(q.value)
+    return Quantity(mag.astype(dtype, **kwargs), q.unit)

--- a/src/duq/_numpy/_functions.py
+++ b/src/duq/_numpy/_functions.py
@@ -1,0 +1,562 @@
+"""The curated ``__array_function__`` table: NumPy function -> duq unit rule.
+
+Each handler receives the original ``(args, kwargs)``, strips Quantity operands
+to bare magnitudes (converting where a rule demands it), calls the underlying
+NumPy function, and re-boxes the result with the correct unit.  Functions absent
+from :data:`FUNCTION_TABLE` fail loud in :mod:`duq._numpy._dispatch`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from duq._errors import DimensionalityError, UnsupportedOperationError
+
+from ._common import (
+    Quantity,
+    box,
+    convert_sequence,
+    dimensionless_unit,
+    find_quantity,
+    magnitude,
+    registry_of,
+    to_unit,
+    unit_of,
+)
+from ._common import dimension_of as _dimension_of
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from duq._unit import Unit
+
+    Handler = Callable[[tuple[object, ...], dict[str, Any]], object]
+
+__all__ = ("FUNCTION_TABLE",)
+
+# A dynamically-typed view of NumPy: these handlers feed already-stripped (unit-
+# free) magnitudes plus forwarded ``*args``/``**kwargs`` straight through to the
+# corresponding NumPy function, so per-call static overload resolution adds no
+# safety here and only fights the deliberately generic ``object`` signatures.
+_np: Any = np
+
+
+def _rebox(result: object, unit: Unit) -> object:
+    if isinstance(result, tuple):
+        return tuple(box(r, unit) for r in result)
+    if isinstance(result, list):
+        return [box(r, unit) for r in result]
+    return box(result, unit)
+
+
+def _reference_unit(*operands: object) -> Unit:
+    for operand in operands:
+        found = find_quantity(operand)
+        if found is not None:
+            return found.unit
+    raise UnsupportedOperationError("expected at least one duq.Quantity operand")
+
+
+# -- preserve / squared ------------------------------------------------------
+
+
+def _make_preserve_first(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        first = args[0]
+        unit = unit_of(first)
+        result = func(magnitude(first), *args[1:], **kwargs)
+        return _rebox(result, unit) if unit is not None else result
+
+    return handler
+
+
+def _make_squared_first(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        first = args[0]
+        unit = unit_of(first)
+        assert unit is not None
+        result = func(magnitude(first), *args[1:], **kwargs)
+        return _rebox(result, unit**2)
+
+    return handler
+
+
+def _make_plain_first(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        return func(magnitude(args[0]), *args[1:], **kwargs)
+
+    return handler
+
+
+# -- joining / selection -----------------------------------------------------
+
+
+def _make_concat(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        sequence = args[0]
+        assert isinstance(sequence, list | tuple)
+        unit = _reference_unit(sequence)
+        mags = convert_sequence(sequence, unit)
+        result = func(mags, *args[1:], **kwargs)
+        return box(result, unit)
+
+    return handler
+
+
+def _h_append(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    arr, values = args[0], args[1]
+    unit = unit_of(arr) if unit_of(arr) is not None else unit_of(values)
+    assert unit is not None
+    result = _np.append(to_unit(arr, unit), to_unit(values, unit), *args[2:], **kwargs)
+    return box(result, unit)
+
+
+def _h_insert(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    arr, obj = args[0], args[1]
+    values = args[2] if len(args) > 2 else kwargs.pop("values")
+    unit = unit_of(arr)
+    assert unit is not None
+    result = _np.insert(magnitude(arr), magnitude(obj), to_unit(values, unit), *args[3:], **kwargs)
+    return box(result, unit)
+
+
+def _h_where(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    if len(args) == 1:
+        return _np.where(magnitude(args[0]))
+    cond, a, b = args[0], args[1], args[2]
+    unit = unit_of(a) if unit_of(a) is not None else unit_of(b)
+    if unit is None:
+        return _np.where(magnitude(cond), magnitude(a), magnitude(b))
+    return box(_np.where(magnitude(cond), to_unit(a, unit), to_unit(b, unit)), unit)
+
+
+def _h_clip(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    a = args[0]
+    unit = unit_of(a)
+    assert unit is not None
+    lo = args[1] if len(args) > 1 else kwargs.pop("a_min", kwargs.pop("min", None))
+    hi = args[2] if len(args) > 2 else kwargs.pop("a_max", kwargs.pop("max", None))
+    m_lo = None if lo is None else to_unit(lo, unit)
+    m_hi = None if hi is None else to_unit(hi, unit)
+    return box(_np.clip(magnitude(a), m_lo, m_hi, **kwargs), unit)
+
+
+def _h_compress(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    condition, a = args[0], args[1]
+    unit = unit_of(a)
+    result = _np.compress(magnitude(condition), magnitude(a), *args[2:], **kwargs)
+    return box(result, unit) if unit is not None else result
+
+
+# -- linalg-ish products -----------------------------------------------------
+
+
+def _make_product(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        a, b = args[0], args[1]
+        dl = dimensionless_unit(registry_of(a, b))
+        ua = unit_of(a)
+        ub = unit_of(b)
+        ua = dl if ua is None else ua
+        ub = dl if ub is None else ub
+        result = func(magnitude(a), magnitude(b), *args[2:], **kwargs)
+        return box(result, ua * ub)
+
+    return handler
+
+
+def _h_einsum(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    subscripts, operands = args[0], args[1:]
+    unit: Unit | None = None
+    mags = []
+    for operand in operands:
+        current = unit_of(operand)
+        if current is not None:
+            unit = current if unit is None else unit * current
+        mags.append(magnitude(operand))
+    result = _np.einsum(subscripts, *mags, **kwargs)
+    return box(result, unit) if unit is not None else result
+
+
+# -- comparison / search -----------------------------------------------------
+
+
+def _make_close(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        kwargs = dict(kwargs)
+        a, b = args[0], args[1]
+        unit = unit_of(a) if unit_of(a) is not None else unit_of(b)
+        assert unit is not None
+        ma, mb = to_unit(a, unit), to_unit(b, unit)
+        rtol = kwargs.pop("rtol", args[2] if len(args) > 2 else 1e-05)
+        atol_positional = args[3] if len(args) > 3 else None
+        atol_given = "atol" in kwargs or len(args) > 3
+        atol_raw = kwargs.pop("atol", atol_positional)
+        if isinstance(atol_raw, Quantity):
+            atol: Any = to_unit(atol_raw, unit)
+        elif atol_given:
+            if not unit.is_dimensionless:
+                raise DimensionalityError(
+                    "atol must be a Quantity of the same dimension as the compared "
+                    "arrays (a bare atol is only valid for dimensionless quantities)"
+                )
+            atol = atol_raw
+        else:
+            if not unit.is_dimensionless:
+                raise DimensionalityError(
+                    "the default atol is only valid for dimensionless quantities; "
+                    "pass an explicit Quantity atol of the same dimension"
+                )
+            atol = 1e-08
+        return func(ma, mb, rtol=rtol, atol=atol, **kwargs)
+
+    return handler
+
+
+def _make_array_equal(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        a, b = args[0], args[1]
+        if _dimension_of(a) != _dimension_of(b):
+            return False
+        unit = unit_of(a) if unit_of(a) is not None else unit_of(b)
+        assert unit is not None
+        return func(to_unit(a, unit), to_unit(b, unit), *args[2:], **kwargs)
+
+    return handler
+
+
+def _h_searchsorted(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    a = args[0]
+    v = args[1] if len(args) > 1 else kwargs.pop("v")
+    unit = unit_of(a)
+    assert unit is not None
+    return _np.searchsorted(magnitude(a), to_unit(v, unit), *args[2:], **kwargs)
+
+
+def _h_digitize(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    x = args[0]
+    bins = args[1] if len(args) > 1 else kwargs.pop("bins")
+    unit = unit_of(x)
+    assert unit is not None
+    return _np.digitize(magnitude(x), to_unit(bins, unit), *args[2:], **kwargs)
+
+
+def _h_unique(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    q = args[0]
+    unit = unit_of(q)
+    assert unit is not None
+    result = _np.unique(magnitude(q), *args[1:], **kwargs)
+    if isinstance(result, tuple):
+        return (box(result[0], unit), *result[1:])
+    return box(result, unit)
+
+
+def _h_interp(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    x, xp, fp = args[0], args[1], args[2]
+    x_unit = unit_of(xp) if unit_of(xp) is not None else unit_of(x)
+    mx = to_unit(x, x_unit) if x_unit is not None else magnitude(x)
+    mxp = to_unit(xp, x_unit) if x_unit is not None else magnitude(xp)
+    fp_unit = unit_of(fp)
+    result = _np.interp(mx, mxp, magnitude(fp), *args[3:], **kwargs)
+    return box(result, fp_unit) if fp_unit is not None else result
+
+
+def _h_meshgrid(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    units = [unit_of(a) for a in args]
+    grids = _np.meshgrid(*(magnitude(a) for a in args), **kwargs)
+    return [box(g, u) if u is not None else g for g, u in zip(grids, units, strict=True)]
+
+
+def _h_histogram(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    a = args[0]
+    unit = unit_of(a)
+    assert unit is not None
+    bins = kwargs.pop("bins", args[1] if len(args) > 1 else 10)
+    if isinstance(bins, Quantity):
+        bins = to_unit(bins, unit)
+    hist_range = kwargs.pop("range", None)
+    if isinstance(hist_range, Quantity):
+        hist_range = to_unit(hist_range, unit)
+    counts, edges = _np.histogram(magnitude(a), bins=bins, range=hist_range, **kwargs)
+    return counts, box(edges, unit)
+
+
+# -- calculus ----------------------------------------------------------------
+
+
+def _h_gradient(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    f = args[0]
+    f_unit = unit_of(f)
+    assert f_unit is not None
+    out_unit = f_unit
+    mags = [magnitude(f)]
+    for spacing in args[1:]:
+        spacing_unit = unit_of(spacing)
+        if spacing_unit is not None:
+            out_unit = f_unit / spacing_unit
+        mags.append(magnitude(spacing))
+    result = _np.gradient(*mags, **kwargs)
+    if isinstance(result, list):
+        return [box(r, out_unit) for r in result]
+    return box(result, out_unit)
+
+
+def _make_trapezoid(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        kwargs = dict(kwargs)
+        y = args[0]
+        y_unit = unit_of(y)
+        assert y_unit is not None
+        out_unit = y_unit
+        x = kwargs.pop("x", args[1] if len(args) > 1 else None)
+        dx = kwargs.pop("dx", None)
+        if x is not None:
+            x_unit = unit_of(x)
+            if x_unit is not None:
+                out_unit = y_unit * x_unit
+            kwargs["x"] = magnitude(x)
+        if dx is not None:
+            dx_unit = unit_of(dx)
+            if dx_unit is not None:
+                out_unit = y_unit * dx_unit
+            kwargs["dx"] = magnitude(dx)
+        return box(func(magnitude(y), **kwargs), out_unit)
+
+    return handler
+
+
+def _h_average(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    a = args[0]
+    unit = unit_of(a)
+    assert unit is not None
+    weights = kwargs.get("weights")
+    if isinstance(weights, Quantity):
+        kwargs["weights"] = magnitude(weights)
+    result = _np.average(magnitude(a), *args[1:], **kwargs)
+    if isinstance(result, tuple):
+        return box(result[0], unit), result[1]
+    return box(result, unit)
+
+
+# -- creation-like -----------------------------------------------------------
+
+
+def _make_like_preserve(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        first = args[0]
+        unit = unit_of(first)
+        assert unit is not None
+        return box(func(magnitude(first), *args[1:], **kwargs), unit)
+
+    return handler
+
+
+def _h_full_like(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    a = args[0]
+    unit = unit_of(a)
+    assert unit is not None
+    fill = args[1] if len(args) > 1 else kwargs.pop("fill_value")
+    if isinstance(fill, Quantity):
+        m_fill: Any = to_unit(fill, unit)
+    elif unit.is_dimensionless:
+        m_fill = fill
+    else:
+        raise DimensionalityError(
+            "full_like fill_value must be a Quantity of the same dimension for a "
+            "dimensional template array"
+        )
+    return box(_np.full_like(magnitude(a), m_fill, *args[2:], **kwargs), unit)
+
+
+# -- shape/layout with multiple outputs --------------------------------------
+
+_PAD_MODES = frozenset({"constant", "edge", "reflect", "symmetric", "wrap"})
+
+
+def _h_pad(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    kwargs = dict(kwargs)
+    array = args[0]
+    unit = unit_of(array)
+    assert unit is not None
+    pad_width = args[1] if len(args) > 1 else kwargs.pop("pad_width")
+    mode = args[2] if len(args) > 2 else kwargs.pop("mode", "constant")
+    if mode not in _PAD_MODES:
+        raise UnsupportedOperationError(
+            f"numpy.pad mode {mode!r} is not supported by duq; use 'constant' or an "
+            "edge-family mode (edge/reflect/symmetric/wrap)"
+        )
+    if "constant_values" in kwargs and isinstance(kwargs["constant_values"], Quantity):
+        kwargs["constant_values"] = to_unit(kwargs["constant_values"], unit)
+    return box(_np.pad(magnitude(array), pad_width, mode=mode, **kwargs), unit)
+
+
+def _h_broadcast_arrays(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    units = [unit_of(a) for a in args]
+    results = _np.broadcast_arrays(*(magnitude(a) for a in args), **kwargs)
+    return [box(r, u) if u is not None else r for r, u in zip(results, units, strict=True)]
+
+
+def _make_atleast(func: Any) -> Handler:
+    def handler(args: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        units = [unit_of(a) for a in args]
+        result = func(*(magnitude(a) for a in args))
+        if len(args) == 1:
+            unit = units[0]
+            return box(result, unit) if unit is not None else result
+        return [box(r, u) if u is not None else r for r, u in zip(result, units, strict=True)]
+
+    return handler
+
+
+# -- table -------------------------------------------------------------------
+
+
+def _build_table() -> dict[Any, Handler]:
+    table: dict[Any, Handler] = {}
+
+    def register(name: str, handler: Handler, *, module: Any = np) -> None:
+        """Register an already-built handler by function name (if it exists)."""
+        func = getattr(module, name, None)
+        if func is not None:
+            table[func] = handler
+
+    def register_factory(name: str, factory: Any, *, module: Any = np) -> None:
+        """Register ``factory(func)`` for ``module.name`` (skipping absent names)."""
+        func = getattr(module, name, None)
+        if func is not None:
+            table[func] = factory(func)
+
+    preserve_names = (
+        # shape / layout
+        "reshape",
+        "ravel",
+        "transpose",
+        "permute_dims",
+        "swapaxes",
+        "moveaxis",
+        "squeeze",
+        "expand_dims",
+        "broadcast_to",
+        "flip",
+        "fliplr",
+        "flipud",
+        "roll",
+        "rot90",
+        "tile",
+        "repeat",
+        "delete",
+        "take",
+        "take_along_axis",
+        "diagonal",
+        "diag",
+        "real",
+        "imag",
+        "copy",
+        "sort",
+        "flatnonzero",
+        "split",
+        "array_split",
+        "hsplit",
+        "vsplit",
+        "dsplit",
+        # reductions preserving the unit
+        "sum",
+        "nansum",
+        "cumsum",
+        "nancumsum",
+        "mean",
+        "nanmean",
+        "median",
+        "nanmedian",
+        "quantile",
+        "percentile",
+        "nanquantile",
+        "nanpercentile",
+        "min",
+        "amin",
+        "max",
+        "amax",
+        "nanmin",
+        "nanmax",
+        "ptp",
+        "std",
+        "nanstd",
+        "diff",
+        "ediff1d",
+        "trace",
+        "around",
+        "round",
+    )
+    for name in preserve_names:
+        register_factory(name, _make_preserve_first)
+
+    for name in ("var", "nanvar"):
+        register_factory(name, _make_squared_first)
+
+    plain_names = (
+        "argmin",
+        "argmax",
+        "nanargmin",
+        "nanargmax",
+        "argsort",
+        "count_nonzero",
+        "nonzero",
+        "shape",
+        "ndim",
+        "size",
+    )
+    for name in plain_names:
+        register_factory(name, _make_plain_first)
+
+    for name in ("concatenate", "stack", "hstack", "vstack", "dstack", "column_stack"):
+        register_factory(name, _make_concat)
+    register("append", _h_append)
+    register("insert", _h_insert)
+    register("where", _h_where)
+    register("clip", _h_clip)
+    register("compress", _h_compress)
+
+    for name in ("dot", "vdot", "inner", "outer", "tensordot", "cross", "kron"):
+        register_factory(name, _make_product)
+    register("einsum", _h_einsum)
+    register_factory("norm", _make_preserve_first, module=np.linalg)
+
+    register_factory("allclose", _make_close)
+    register_factory("isclose", _make_close)
+    register_factory("array_equal", _make_array_equal)
+    register_factory("array_equiv", _make_array_equal)
+    register("searchsorted", _h_searchsorted)
+    register("digitize", _h_digitize)
+    register("unique", _h_unique)
+    register("interp", _h_interp)
+    register("meshgrid", _h_meshgrid)
+    register("histogram", _h_histogram)
+    register("average", _h_average)
+
+    register("gradient", _h_gradient)
+    for name in ("trapezoid", "trapz"):  # numpy>=2 vs 1.26 naming
+        register_factory(name, _make_trapezoid)
+
+    for name in ("zeros_like", "empty_like", "ones_like"):
+        register_factory(name, _make_like_preserve)
+    register("full_like", _h_full_like)
+
+    register("pad", _h_pad)
+    register("broadcast_arrays", _h_broadcast_arrays)
+    for name in ("atleast_1d", "atleast_2d", "atleast_3d"):
+        register_factory(name, _make_atleast)
+
+    return table
+
+
+#: The curated ``__array_function__`` dispatch table (keyed by function object).
+FUNCTION_TABLE: dict[Any, Handler] = _build_table()

--- a/src/duq/_numpy/_ufuncs.py
+++ b/src/duq/_numpy/_ufuncs.py
@@ -1,0 +1,314 @@
+"""The curated ``__array_ufunc__`` table: NumPy ufunc -> duq unit rule.
+
+Every supported ufunc maps to a small handler that strips its operands to bare
+magnitudes, applies the unit rule from :mod:`duq._rules` (or direct unit
+algebra), calls the underlying ufunc on the magnitudes, and re-boxes the result.
+Anything absent from :data:`UFUNC_TABLE` fails loud in :mod:`duq._numpy._dispatch`.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from duq._errors import AffineUnitError, UnsupportedOperationError
+
+from ._common import (
+    Quantity,
+    Unit,
+    box,
+    compare_core,
+    dimensionless_unit,
+    magnitude,
+    registry_of,
+    reject_affine,
+    require_dimensionless_raw,
+    to_pure,
+    to_unit,
+    unit_of,
+    unit_power,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    Handler = Callable[[Any, tuple[object, ...], dict[str, Any]], object]
+
+__all__ = ("REDUCE_PRESERVE", "UFUNC_TABLE")
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def _binary(inputs: tuple[object, ...]) -> tuple[object, object]:
+    a, b = inputs
+    return a, b
+
+
+def _resolved_unit(x: object, dimensionless: Unit) -> Unit:
+    unit = unit_of(x)
+    return dimensionless if unit is None else unit
+
+
+# -- multiplicative ---------------------------------------------------------
+
+
+def _h_multiply(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    a, b = _binary(inputs)
+    reject_affine(unit_of(a), unit_of(b))
+    dl = dimensionless_unit(registry_of(a, b))
+    ua = _resolved_unit(a, dl)
+    ub = _resolved_unit(b, dl)
+    result = ufunc(magnitude(a), magnitude(b), **kwargs)
+    return box(result, ua * ub)
+
+
+def _h_divide(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    a, b = _binary(inputs)
+    reject_affine(unit_of(a), unit_of(b))
+    dl = dimensionless_unit(registry_of(a, b))
+    ua = _resolved_unit(a, dl)
+    ub = _resolved_unit(b, dl)
+    result = ufunc(magnitude(a), magnitude(b), **kwargs)
+    return box(result, ua / ub)
+
+
+# -- additive / same-dimension ----------------------------------------------
+
+
+def _box_pair(inputs: tuple[object, ...]) -> tuple[Any, Any]:
+    a, b = _binary(inputs)
+    dl = dimensionless_unit(registry_of(a, b))
+    qa = a if isinstance(a, Quantity) else Quantity(a, dl)  # type: ignore[arg-type]
+    qb = b if isinstance(b, Quantity) else Quantity(b, dl)  # type: ignore[arg-type]
+    return qa, qb
+
+
+def _h_add(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    qa, qb = _box_pair(inputs)
+    return qa + qb
+
+
+def _h_subtract(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    qa, qb = _box_pair(inputs)
+    return qa - qb
+
+
+def _h_same_dim(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    a, b = _binary(inputs)
+    ua, ub = unit_of(a), unit_of(b)
+    reference = ua if ua is not None else ub
+    assert reference is not None  # a ufunc is dispatched only with a Quantity operand
+    ma = to_unit(a, reference)
+    mb = to_unit(b, reference)
+    result = ufunc(ma, mb, **kwargs)
+    return box(result, reference)
+
+
+# -- powers -----------------------------------------------------------------
+
+
+def _h_power(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    base, exponent = _binary(inputs)
+    exp_pure = to_pure(exponent)
+    exp_arr = np.asarray(exp_pure)
+    if exp_arr.ndim == 0:
+        exp_value = exp_arr.item()
+    else:
+        first = exp_arr.reshape(-1)[0].item()
+        if not bool(np.all(exp_arr == first)):
+            raise UnsupportedOperationError(
+                "numpy power with an array of differing exponents is unsupported: "
+                "each element would carry a different unit"
+            )
+        exp_value = first
+    result = ufunc(magnitude(base), exp_pure, **kwargs)
+    ubase = unit_of(base)
+    if ubase is None:
+        return result
+    return box(result, unit_power(ubase, exp_value))
+
+
+def _make_unit_pow(exponent: Fraction) -> Handler:
+    def handler(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        (x,) = inputs
+        result = ufunc(magnitude(x), **kwargs)
+        unit = unit_of(x)
+        if unit is None:
+            return result
+        return box(result, unit**exponent)
+
+    return handler
+
+
+# -- unary preserving / stripping -------------------------------------------
+
+_AFFINE_FORBIDDEN = frozenset({np.negative, np.absolute, np.fabs})
+
+
+def _h_preserve_unary(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    (x,) = inputs
+    unit = unit_of(x)
+    if unit is not None and unit.is_affine and ufunc in _AFFINE_FORBIDDEN:
+        raise AffineUnitError(f"cannot apply {ufunc.__name__} to an affine quantity such as °C")
+    result = ufunc(magnitude(x), **kwargs)
+    return result if unit is None else box(result, unit)
+
+
+def _h_strip_unary(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    """Apply a ufunc to the raw magnitude and return a plain array (sign, isnan...)."""
+    (x,) = inputs
+    return ufunc(magnitude(x), **kwargs)
+
+
+# -- dimensionless / angle ---------------------------------------------------
+
+
+def _h_dimensionless_unary(
+    ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]
+) -> object:
+    (x,) = inputs
+    result = ufunc(to_pure(x), **kwargs)
+    return box(result, dimensionless_unit(registry_of(x)))
+
+
+def _h_dimensionless_binary(
+    ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]
+) -> object:
+    a, b = _binary(inputs)
+    result = ufunc(to_pure(a), to_pure(b), **kwargs)
+    return box(result, dimensionless_unit(registry_of(a, b)))
+
+
+def _h_inverse_trig(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    (x,) = inputs
+    result = ufunc(to_pure(x), **kwargs)
+    return box(result, registry_of(x).unit("rad"))
+
+
+def _h_arctan2(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    a, b = _binary(inputs)
+    ua, ub = unit_of(a), unit_of(b)
+    reference = ua if ua is not None else ub
+    assert reference is not None
+    result = ufunc(to_unit(a, reference), to_unit(b, reference), **kwargs)
+    return box(result, registry_of(a, b).unit("rad"))
+
+
+def _make_angle_convert(out_unit: str) -> Handler:
+    def handler(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        (x,) = inputs
+        result = ufunc(require_dimensionless_raw(x), **kwargs)
+        return box(result, registry_of(x).unit(out_unit))
+
+    return handler
+
+
+def _h_copysign(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+    a, b = _binary(inputs)
+    ua = unit_of(a)
+    assert ua is not None
+    # Only the sign of ``b`` is used; a same-dimension check keeps it meaningful.
+    mb = to_unit(b, ua) if unit_of(b) is not None else magnitude(b)
+    result = ufunc(magnitude(a), mb, **kwargs)
+    return box(result, ua)
+
+
+# -- comparisons -------------------------------------------------------------
+
+
+def _make_compare(op_name: str) -> Handler:
+    def handler(ufunc: Any, inputs: tuple[object, ...], kwargs: dict[str, Any]) -> object:
+        a, b = _binary(inputs)
+        return compare_core(op_name, a, b)
+
+    return handler
+
+
+# -- table -------------------------------------------------------------------
+
+#: Ufuncs whose ``reduce``/``accumulate`` preserve the unit.
+REDUCE_PRESERVE: frozenset[Any] = frozenset({np.add, np.maximum, np.minimum})
+
+
+def _build_table() -> dict[Any, Handler]:
+    table: dict[Any, Handler] = {}
+
+    def each(handler: Handler, *ufuncs: Any) -> None:
+        for ufunc in ufuncs:
+            table[ufunc] = handler
+
+    each(_h_multiply, np.multiply, np.matmul)
+    each(_h_divide, np.divide, np.true_divide, np.floor_divide)
+    each(_h_add, np.add)
+    each(_h_subtract, np.subtract)
+    each(
+        _h_same_dim,
+        np.hypot,
+        np.maximum,
+        np.minimum,
+        np.fmax,
+        np.fmin,
+        np.remainder,
+        np.mod,
+        np.fmod,
+        np.nextafter,
+    )
+    each(_h_copysign, np.copysign)
+    each(_h_power, np.power, np.float_power)
+
+    each(_make_unit_pow(Fraction(1, 2)), np.sqrt)
+    each(_make_unit_pow(Fraction(1, 3)), np.cbrt)
+    each(_make_unit_pow(Fraction(2)), np.square)
+    each(_make_unit_pow(Fraction(-1)), np.reciprocal)
+
+    each(
+        _h_preserve_unary,
+        np.negative,
+        np.positive,
+        np.absolute,
+        np.fabs,
+        np.conjugate,
+        np.floor,
+        np.ceil,
+        np.trunc,
+        np.rint,
+    )
+    each(_h_strip_unary, np.sign, np.isfinite, np.isnan, np.isinf, np.signbit)
+
+    each(
+        _h_dimensionless_unary,
+        np.exp,
+        np.exp2,
+        np.expm1,
+        np.log,
+        np.log2,
+        np.log10,
+        np.log1p,
+        np.sinh,
+        np.cosh,
+        np.tanh,
+        np.arcsinh,
+        np.arccosh,
+        np.arctanh,
+        np.sin,
+        np.cos,
+        np.tan,
+    )
+    each(_h_dimensionless_binary, np.logaddexp, np.logaddexp2)
+    each(_h_inverse_trig, np.arcsin, np.arccos, np.arctan)
+    each(_h_arctan2, np.arctan2)
+
+    each(_make_angle_convert("rad"), np.deg2rad, np.radians)
+    each(_make_angle_convert("deg"), np.rad2deg, np.degrees)
+
+    for name in ("equal", "not_equal", "less", "less_equal", "greater", "greater_equal"):
+        each(_make_compare(name), getattr(np, name))
+
+    return table
+
+
+#: The curated ufunc dispatch table (keyed by ufunc object).
+UFUNC_TABLE: dict[Any, Handler] = _build_table()

--- a/src/duq/_quantity.py
+++ b/src/duq/_quantity.py
@@ -6,8 +6,10 @@
 right operand to the left operand's unit, equality is *exact* after conversion,
 and everything is immutable and hashable.
 
-Importing this module never imports NumPy; the NumPy protocol hooks are defined
-but deliberately raise until the array layer ships.
+Importing this module never imports NumPy: the scalar arithmetic path is pure
+Python, and the NumPy protocol hooks (:meth:`Quantity.__array_ufunc__`,
+:meth:`Quantity.__array_function__`, :meth:`Quantity.__array__`) import the
+:mod:`duq._numpy` back-end lazily, only when NumPy actually calls them.
 """
 
 from __future__ import annotations
@@ -17,6 +19,7 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Final
 
+from ._arraytypes import is_numpy_array, is_numpy_magnitude
 from ._dimension import Dimension, _coerce_exponent
 from ._errors import (
     AffineUnitError,
@@ -27,9 +30,6 @@ from ._registry import default_registry
 from ._rules import Rule, apply
 from ._unit import Factor, Unit
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
 __all__ = ("Quantity", "uconvert", "ustrip")
 
 Number = int | float | complex | Fraction | Decimal
@@ -37,10 +37,20 @@ Number = int | float | complex | Fraction | Decimal
 
 Scalar = Fraction | float
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import numpy as np
+    import numpy.typing as npt
+
+    #: A NumPy array magnitude (any dtype).
+    NDArray = npt.NDArray[Any]
+    #: Everything a :class:`Quantity` can wrap: a Python scalar, a NumPy array,
+    #: or a NumPy scalar (``numpy.generic``).
+    Magnitude = Number | NDArray | np.generic
+
 #: Avogadro constant as an exact integer Fraction (CODATA 2022, exact by SI).
 _AVOGADRO: Final[Fraction] = Fraction(602214076 * 10**15)
-
-_NUMPY_MESSAGE = "numpy support lands in duq.numpy (PR 3)"
 
 
 def _to_decimal(x: Scalar | int) -> Decimal:
@@ -54,48 +64,66 @@ def _as_complex(factor: Scalar) -> complex | float:
     return complex(float(factor)) if isinstance(factor, Fraction) else factor
 
 
-def _to_float(value: Number) -> float:
+def _to_float(value: Any) -> float:
     """Return a real float magnitude (the modulus for complex values)."""
     if isinstance(value, complex):
         return abs(value)
     return float(value)
 
 
-def _mul(value: Number, factor: Scalar) -> Number:
+def _as_array_factor(factor: Scalar) -> float | complex:
+    """Coerce a scale/offset to a float a NumPy array can combine with.
+
+    A NumPy float array multiplied by a :class:`~fractions.Fraction` silently
+    produces an ``object``-dtype array; converting the factor to ``float`` first
+    keeps the result a native numeric array.
+    """
+    return float(factor) if isinstance(factor, Fraction) else factor
+
+
+def _mul(value: Any, factor: Scalar) -> Any:
     if isinstance(value, Decimal):
         return value * _to_decimal(factor)
     if isinstance(value, complex):
         return value * _as_complex(factor)
+    if is_numpy_magnitude(value):
+        return value * _as_array_factor(factor)
     return value * factor
 
 
-def _add(value: Number, addend: Scalar) -> Number:
+def _add(value: Any, addend: Scalar) -> Any:
     if addend == 0:
         return value
     if isinstance(value, Decimal):
         return value + _to_decimal(addend)
     if isinstance(value, complex):
         return value + _as_complex(addend)
+    if is_numpy_magnitude(value):
+        return value + _as_array_factor(addend)
     return value + addend
 
 
-def _sub(value: Number, subtrahend: Scalar) -> Number:
+def _sub(value: Any, subtrahend: Scalar) -> Any:
     if subtrahend == 0:
         return value
     if isinstance(value, Decimal):
         return value - _to_decimal(subtrahend)
     if isinstance(value, complex):
         return value - _as_complex(subtrahend)
+    if is_numpy_magnitude(value):
+        return value - _as_array_factor(subtrahend)
     return value - subtrahend
 
 
-def _div(value: Number, divisor: Scalar) -> Number:
+def _div(value: Any, divisor: Scalar) -> Any:
     if divisor == 1:
         return value
     if isinstance(value, Decimal):
         return value / _to_decimal(divisor)
     if isinstance(value, complex):
         return value / _as_complex(divisor)
+    if is_numpy_magnitude(value):
+        return value / _as_array_factor(divisor)
     return value / divisor
 
 
@@ -107,32 +135,33 @@ def _avogadro_power(power: Fraction) -> Scalar:
     return inexact
 
 
-# Value-by-value arithmetic across the numeric tower.  Mixing incompatible
-# concrete types (e.g. a Decimal quantity with a float one) raises TypeError at
-# runtime, which is the intended behaviour; the localized ignores acknowledge
-# that mypy cannot prove the operands share a concrete type.
-def _num_add(a: Number, b: Number) -> Number:
-    return a + b  # type: ignore[operator]
+# Value-by-value arithmetic that is polymorphic over the whole numeric tower
+# *and* NumPy magnitudes; typed ``Any`` because a single static type cannot span
+# int/float/complex/Fraction/Decimal and ndarray simultaneously.  Mixing
+# incompatible concrete types (e.g. a Decimal with a float) raises TypeError at
+# runtime, which is the intended behaviour.
+def _num_add(a: Any, b: Any) -> Any:
+    return a + b
 
 
-def _num_sub(a: Number, b: Number) -> Number:
-    return a - b  # type: ignore[operator]
+def _num_sub(a: Any, b: Any) -> Any:
+    return a - b
 
 
-def _num_mul(a: Number, b: Number) -> Number:
-    return a * b  # type: ignore[operator]
+def _num_mul(a: Any, b: Any) -> Any:
+    return a * b
 
 
-def _num_div(a: Number, b: Number) -> Number:
-    return a / b  # type: ignore[operator]
+def _num_div(a: Any, b: Any) -> Any:
+    return a / b
 
 
-def _num_pow(a: Number, b: int | Fraction) -> Number:
-    return a**b  # type: ignore[operator]
+def _num_pow(a: Any, b: int | Fraction) -> Any:
+    return a**b
 
 
-def _num_abs(a: Number) -> Number:
-    return abs(a)  # type: ignore[return-value]
+def _num_abs(a: Any) -> Any:
+    return abs(a)
 
 
 def _unit_is_affine(unit: Unit) -> bool:
@@ -145,10 +174,15 @@ class Quantity:
 
     Parameters
     ----------
-    value : int, float, complex, fractions.Fraction or decimal.Decimal
-        The numeric magnitude.
+    value : int, float, complex, fractions.Fraction, decimal.Decimal or numpy.ndarray
+        The numeric magnitude.  A NumPy array (or NumPy scalar) is stored as-is
+        -- no copy is made -- turning the quantity into a unit-carrying array.
     unit : str or Unit
         The unit; strings are parsed against the default registry.
+
+    See Also
+    --------
+    Quantity.from_array : Build an array quantity from any array-like (e.g. a list).
 
     Examples
     --------
@@ -160,19 +194,30 @@ class Quantity:
     2.3
     >>> duq.Quantity(1.0, "km") == duq.Quantity(1000.0, "m")
     True
+
+    A NumPy array magnitude turns the quantity into a unit-carrying array; units
+    propagate through ufuncs, reductions and ``__array_function__``:
+
+    >>> import numpy as np
+    >>> q = duq.Quantity(np.array([1.0, 2.0, 3.0]), "m")
+    >>> np.sqrt(q * q).unit == duq.unit("m")
+    True
+    >>> float(q.sum().value)
+    6.0
     """
 
     __slots__ = ("_unit", "_value")
-    _value: Number
+    _value: Magnitude
     _unit: Unit
 
-    def __init__(self, value: Number, unit: str | Unit) -> None:
-        if isinstance(value, bool) or not isinstance(
-            value, int | float | complex | Fraction | Decimal
+    def __init__(self, value: Magnitude, unit: str | Unit) -> None:
+        if isinstance(value, bool) or not (
+            isinstance(value, int | float | complex | Fraction | Decimal)
+            or is_numpy_magnitude(value)
         ):
             raise TypeError(
-                f"value must be int, float, complex, Fraction or Decimal, "
-                f"not {type(value).__name__}"
+                f"value must be int, float, complex, Fraction, Decimal or a NumPy "
+                f"array, not {type(value).__name__}"
             )
         if isinstance(unit, str):
             resolved = default_registry.unit(unit)
@@ -183,15 +228,51 @@ class Quantity:
         object.__setattr__(self, "_value", value)
         object.__setattr__(self, "_unit", resolved)
 
+    @classmethod
+    def from_array(cls, value: object, unit: str | Unit) -> Quantity:
+        """Build an array quantity from any array-like magnitude.
+
+        Unlike the constructor (which requires a NumPy array or a Python scalar),
+        this coerces ``value`` with :func:`numpy.asarray`, so Python lists and
+        other sequences become array quantities.
+
+        Parameters
+        ----------
+        value : array_like
+            Anything :func:`numpy.asarray` accepts (list, tuple, ndarray, ...).
+        unit : str or Unit
+            The unit; strings are parsed against the default registry.
+
+        Returns
+        -------
+        Quantity
+            An array-backed quantity.
+
+        Examples
+        --------
+        >>> import duq
+        >>> q = duq.Quantity.from_array([1.0, 2.0, 3.0], "m")
+        >>> q.shape
+        (3,)
+        """
+        import numpy as np
+
+        return cls(np.asarray(value), unit)
+
     def __setattr__(self, name: str, value: object) -> None:  # pragma: no cover
         raise AttributeError("Quantity is immutable")
 
     # -- properties ---------------------------------------------------------
 
     @property
-    def value(self) -> Number:
+    def value(self) -> Magnitude:
         """Return the numeric magnitude."""
         return self._value
+
+    @property
+    def is_array(self) -> bool:
+        """Return whether the magnitude is a NumPy array."""
+        return is_numpy_array(self._value)
 
     @property
     def unit(self) -> Unit:
@@ -203,9 +284,10 @@ class Quantity:
         """Return the physical dimension."""
         return self._unit.dimension
 
-    def _si_value(self) -> Number:
+    def _si_value(self) -> Magnitude:
         """Return the magnitude expressed in the coherent SI unit."""
-        return _add(_mul(self._value, self._unit.scale), self._unit.offset)
+        result: Magnitude = _add(_mul(self._value, self._unit.scale), self._unit.offset)
+        return result
 
     # -- conversion ---------------------------------------------------------
 
@@ -286,7 +368,7 @@ class Quantity:
         """
         return self.to(self._unit.registry.coherent_unit(self.dimension))
 
-    def value_in(self, unit: str | Unit) -> Number:
+    def value_in(self, unit: str | Unit) -> Magnitude:
         """Return the magnitude expressed in ``unit``.
 
         Parameters
@@ -296,7 +378,7 @@ class Quantity:
 
         Returns
         -------
-        int, float, complex, fractions.Fraction or decimal.Decimal
+        int, float, complex, fractions.Fraction, decimal.Decimal or numpy.ndarray
             The converted magnitude.
 
         Examples
@@ -325,6 +407,10 @@ class Quantity:
         >>> c.value, str(c.unit)
         (1.5, 'km')
         """
+        if self.is_array:
+            raise UnsupportedOperationError(
+                "compact() is defined only for scalar quantities, not array magnitudes"
+            )
         if self._unit.is_dimensionless or self._value == 0:
             return self
         factors = self._unit.factors
@@ -478,17 +564,33 @@ class Quantity:
 
     # -- comparison ---------------------------------------------------------
 
-    def _compare_value(self, other: Quantity) -> Number:
+    def _compare_value(self, other: Quantity) -> Magnitude:
         return other.to(self._unit)._value
 
-    def __eq__(self, other: object) -> bool:
+    def _array_compare(self, other: object) -> bool:
+        """Return whether a comparison with ``other`` involves a NumPy array."""
+        if is_numpy_magnitude(self._value):
+            return True
+        if isinstance(other, Quantity):
+            return is_numpy_magnitude(other._value)
+        return is_numpy_magnitude(other)
+
+    def __eq__(self, other: object) -> bool | NDArray:  # type: ignore[override]
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("equal", self, other)
         if not isinstance(other, Quantity):
             return NotImplemented
         if self.dimension != other.dimension:
             return False
-        return self._value == self._compare_value(other)
+        return bool(self._value == self._compare_value(other))
 
-    def __ne__(self, other: object) -> bool:
+    def __ne__(self, other: object) -> bool | NDArray:  # type: ignore[override]
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("not_equal", self, other)
         result = self.__eq__(other)
         if result is NotImplemented:
             return NotImplemented
@@ -503,19 +605,35 @@ class Quantity:
         apply(Rule.SAME_DIM, self.dimension, other.dimension)
         return op(self._value, self._compare_value(other))
 
-    def __lt__(self, other: object) -> bool:
+    def __lt__(self, other: object) -> bool | NDArray:
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("less", self, other)
         result = self._order(other, lambda a, b: a < b)
         return NotImplemented if result is None else result
 
-    def __le__(self, other: object) -> bool:
+    def __le__(self, other: object) -> bool | NDArray:
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("less_equal", self, other)
         result = self._order(other, lambda a, b: a <= b)
         return NotImplemented if result is None else result
 
-    def __gt__(self, other: object) -> bool:
+    def __gt__(self, other: object) -> bool | NDArray:
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("greater", self, other)
         result = self._order(other, lambda a, b: a > b)
         return NotImplemented if result is None else result
 
-    def __ge__(self, other: object) -> bool:
+    def __ge__(self, other: object) -> bool | NDArray:
+        if self._array_compare(other):
+            from ._numpy import richcompare
+
+            return richcompare("greater_equal", self, other)
         result = self._order(other, lambda a, b: a >= b)
         return NotImplemented if result is None else result
 
@@ -544,6 +662,10 @@ class Quantity:
         >>> a.allclose(b)
         True
         """
+        if self.is_array or other.is_array:
+            raise UnsupportedOperationError(
+                "Quantity.allclose is for scalars; use numpy.allclose on array quantities"
+            )
         apply(Rule.SAME_DIM, self.dimension, other.dimension)
         return math.isclose(
             _to_float(self._value),
@@ -552,15 +674,242 @@ class Quantity:
             abs_tol=abs_tol,
         )
 
-    # -- numpy stubs (fail loud until PR 3) ---------------------------------
+    # -- numpy protocol (NEP 13 / NEP 18) -----------------------------------
 
-    def __array_ufunc__(self, *args: object, **kwargs: object) -> object:
-        """Reject NumPy ufuncs until the array layer ships."""
-        raise UnsupportedOperationError(_NUMPY_MESSAGE)
+    def __array_ufunc__(
+        self, ufunc: object, method: str, *inputs: object, **kwargs: object
+    ) -> object:
+        """Dispatch a NumPy ufunc through the curated duq unit-rule table.
 
-    def __array_function__(self, *args: object, **kwargs: object) -> object:
-        """Reject NumPy functions until the array layer ships."""
-        raise UnsupportedOperationError(_NUMPY_MESSAGE)
+        Any ufunc/method without a registered rule -- and any ``out=`` argument
+        -- raises :class:`~duq.UnsupportedOperationError`; units are never
+        silently dropped.
+        """
+        from ._numpy import dispatch_ufunc
+
+        return dispatch_ufunc(ufunc, method, inputs, kwargs)
+
+    def __array_function__(
+        self,
+        func: Callable[..., object],
+        types: object,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> object:
+        """Dispatch a NumPy function through the curated duq unit-rule table."""
+        from ._numpy import dispatch_function
+
+        return dispatch_function(func, types, args, kwargs)
+
+    def __array__(self, dtype: object = None, copy: object = None) -> object:
+        """Refuse silent unit-stripping conversion to a bare NumPy array.
+
+        Closing this classic hole is a design goal: ``numpy.array(q)`` and
+        ``numpy.asarray(q)`` must never quietly discard the unit.  Use
+        :func:`duq.ustrip` (or :attr:`value`) to obtain the raw magnitude.
+        """
+        raise UnsupportedOperationError(
+            "refusing to convert a Quantity to a bare NumPy array, which would "
+            "silently drop its unit; use duq.ustrip(unit, q) to get the magnitude "
+            "in a chosen unit (or q.value for the stored magnitude)"
+        )
+
+    def __matmul__(self, other: object) -> object:
+        from ._numpy import matmul
+
+        return matmul(self, other)
+
+    def __rmatmul__(self, other: object) -> object:
+        from ._numpy import matmul
+
+        return matmul(other, self)
+
+    # -- array introspection ------------------------------------------------
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Return the shape of the magnitude (``()`` for a scalar magnitude).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> duq.Quantity(np.zeros((2, 3)), "m").shape
+        (2, 3)
+        """
+        from ._numpy import magnitude_shape
+
+        return magnitude_shape(self._value)
+
+    @property
+    def ndim(self) -> int:
+        """Return the number of magnitude dimensions (``0`` for a scalar)."""
+        from ._numpy import magnitude_ndim
+
+        return magnitude_ndim(self._value)
+
+    @property
+    def size(self) -> int:
+        """Return the number of magnitude elements (``1`` for a scalar)."""
+        from ._numpy import magnitude_size
+
+        return magnitude_size(self._value)
+
+    @property
+    def dtype(self) -> np.dtype[Any]:
+        """Return the NumPy dtype of the magnitude (array magnitudes only)."""
+        from ._numpy import magnitude_dtype
+
+        return magnitude_dtype(self._value)
+
+    @property
+    def T(self) -> Quantity:  # noqa: N802 - mirrors ``ndarray.T``
+        """Return the transposed quantity (unit preserved).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> duq.Quantity(np.zeros((2, 3)), "m").T.shape
+        (3, 2)
+        """
+        from ._numpy import q_transpose
+
+        return q_transpose(self)
+
+    def __len__(self) -> int:
+        from ._numpy import magnitude_len
+
+        return magnitude_len(self._value)
+
+    def __iter__(self) -> Iterator[Quantity]:
+        from ._numpy import iter_quantity
+
+        return iter_quantity(self)
+
+    def __getitem__(self, key: object) -> Quantity:
+        from ._numpy import get_item
+
+        return get_item(self, key)
+
+    def item(self, *args: object) -> Quantity:
+        """Return a single element as a scalar :class:`Quantity` (unit preserved).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> duq.Quantity(np.array([5.0]), "m").item().value
+        5.0
+        """
+        from ._numpy import scalar_item
+
+        return scalar_item(self, args)
+
+    # -- array reductions / reshaping (thin delegates) ----------------------
+
+    def sum(self, **kwargs: object) -> Quantity:
+        """Sum the magnitude, preserving the unit (see :func:`numpy.sum`).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> float(duq.Quantity(np.array([1.0, 2.0, 3.0]), "m").sum().value)
+        6.0
+        """
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "sum", kwargs)
+
+    def mean(self, **kwargs: object) -> Quantity:
+        """Average the magnitude, preserving the unit (see :func:`numpy.mean`)."""
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "mean", kwargs)
+
+    def std(self, **kwargs: object) -> Quantity:
+        """Return the standard deviation, preserving the unit (see :func:`numpy.std`)."""
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "std", kwargs)
+
+    def var(self, **kwargs: object) -> Quantity:
+        """Return the variance, squaring the unit (see :func:`numpy.var`).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> duq.Quantity(np.array([1.0, 2.0, 3.0]), "m").var().unit == duq.unit("m^2")
+        True
+        """
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "var", kwargs, unit_power=2)
+
+    def min(self, **kwargs: object) -> Quantity:
+        """Return the minimum, preserving the unit (see :func:`numpy.min`)."""
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "min", kwargs)
+
+    def max(self, **kwargs: object) -> Quantity:
+        """Return the maximum, preserving the unit (see :func:`numpy.max`)."""
+        from ._numpy import q_reduce
+
+        return q_reduce(self, "max", kwargs)
+
+    def reshape(self, *shape: object, **kwargs: object) -> Quantity:
+        """Reshape the magnitude, preserving the unit (see :func:`numpy.reshape`).
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import duq
+        >>> duq.Quantity(np.arange(6.0), "m").reshape(2, 3).shape
+        (2, 3)
+        """
+        from ._numpy import q_reshape
+
+        return q_reshape(self, shape, kwargs)
+
+    def ravel(self, **kwargs: object) -> Quantity:
+        """Flatten the magnitude, preserving the unit (see :func:`numpy.ravel`)."""
+        from ._numpy import q_ravel
+
+        return q_ravel(self, kwargs)
+
+    def astype(self, dtype: object, **kwargs: object) -> Quantity:
+        """Cast the magnitude to ``dtype``, preserving the unit."""
+        from ._numpy import q_astype
+
+        return q_astype(self, dtype, kwargs)
+
+    # -- scalar coercion (fail loud, never silently strip) ------------------
+
+    def __bool__(self) -> bool:
+        # Defined explicitly so that adding ``__len__`` (for array magnitudes)
+        # does not make ``bool(scalar_quantity)`` fall back to ``__len__``.
+        return bool(self._value)
+
+    def __float__(self) -> float:
+        raise UnsupportedOperationError(
+            "refusing to coerce a Quantity to a bare float, which would drop its "
+            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
+        )
+
+    def __int__(self) -> int:
+        raise UnsupportedOperationError(
+            "refusing to coerce a Quantity to a bare int, which would drop its "
+            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
+        )
+
+    def __complex__(self) -> complex:
+        raise UnsupportedOperationError(
+            "refusing to coerce a Quantity to a bare complex, which would drop its "
+            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
+        )
 
     # -- rendering ----------------------------------------------------------
 
@@ -595,7 +944,7 @@ def uconvert(unit: str | Unit, q: Quantity) -> Quantity:
     return q.to(unit)
 
 
-def ustrip(unit: str | Unit, q: Quantity) -> Number:
+def ustrip(unit: str | Unit, q: Quantity) -> Magnitude:
     """Return a quantity's magnitude in a unit (unit-first, JAX-idiomatic).
 
     Parameters
@@ -607,7 +956,7 @@ def ustrip(unit: str | Unit, q: Quantity) -> Number:
 
     Returns
     -------
-    int, float, complex, fractions.Fraction or decimal.Decimal
+    int, float, complex, fractions.Fraction, decimal.Decimal or numpy.ndarray
         The bare magnitude in ``unit``.
 
     Examples

--- a/src/duq/_quantity.py
+++ b/src/duq/_quantity.py
@@ -886,30 +886,78 @@ class Quantity:
 
         return q_astype(self, dtype, kwargs)
 
-    # -- scalar coercion (fail loud, never silently strip) ------------------
+    # -- scalar coercion (dimensionless converts; dimensional fails loud) ---
+
+    def _as_dimensionless(self, target: str) -> Any:
+        """Return the magnitude in the bare scale-1 dimensionless unit, or fail loud.
+
+        A dimensionless quantity has one unambiguous numeric value once its
+        scale is applied (``50 %`` is ``0.5``; radian-labelled values pass
+        through unchanged), so coercing it never loses information.  Anything
+        dimensional refuses, pointing at :func:`duq.ustrip`.
+        """
+        if self._unit.is_dimensionless:
+            return self._si_value()
+        raise UnsupportedOperationError(
+            f"refusing to coerce a quantity of dimension {self.dimension} to a "
+            f"bare {target}, which would drop its unit; use duq.ustrip(unit, q) "
+            "to get the magnitude in a chosen unit (only dimensionless "
+            "quantities coerce directly)"
+        )
 
     def __bool__(self) -> bool:
-        # Defined explicitly so that adding ``__len__`` (for array magnitudes)
-        # does not make ``bool(scalar_quantity)`` fall back to ``__len__``.
-        return bool(self._value)
+        """Return the truthiness of a dimensionless quantity's magnitude.
+
+        Dimensionless (including angle-labelled and scaled units like ``%``)
+        follows the magnitude's own truthiness -- for array magnitudes that is
+        NumPy's rule (one element coerces, more raise ``ValueError``).
+        Dimensional quantities raise :class:`~duq.UnsupportedOperationError`.
+
+        Examples
+        --------
+        >>> import duq
+        >>> bool(duq.Quantity(0.0, "1")), bool(duq.Quantity(50.0, "%"))
+        (False, True)
+        """
+        return bool(self._as_dimensionless("bool"))
 
     def __float__(self) -> float:
-        raise UnsupportedOperationError(
-            "refusing to coerce a Quantity to a bare float, which would drop its "
-            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
-        )
+        """Return a dimensionless quantity's magnitude as a float (scale applied).
+
+        Dimensional quantities raise :class:`~duq.UnsupportedOperationError`
+        with guidance to use :func:`duq.ustrip` (pint-consistent behaviour).
+
+        Examples
+        --------
+        >>> import duq
+        >>> float(duq.Quantity(50.0, "%"))
+        0.5
+        >>> float(duq.Quantity(1.5, "rad"))
+        1.5
+        """
+        return float(self._as_dimensionless("float"))
 
     def __int__(self) -> int:
-        raise UnsupportedOperationError(
-            "refusing to coerce a Quantity to a bare int, which would drop its "
-            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
-        )
+        """Return a dimensionless quantity's magnitude as an int (scale applied).
+
+        Examples
+        --------
+        >>> import duq
+        >>> int(duq.Quantity(200.0, "%"))
+        2
+        """
+        return int(self._as_dimensionless("int"))
 
     def __complex__(self) -> complex:
-        raise UnsupportedOperationError(
-            "refusing to coerce a Quantity to a bare complex, which would drop its "
-            "unit; use duq.ustrip(unit, q) to get the magnitude in a chosen unit"
-        )
+        """Return a dimensionless quantity's magnitude as a complex (scale applied).
+
+        Examples
+        --------
+        >>> import duq
+        >>> complex(duq.Quantity(50.0, "%"))
+        (0.5+0j)
+        """
+        return complex(self._as_dimensionless("complex"))
 
     # -- rendering ----------------------------------------------------------
 

--- a/src/duq/_unit.py
+++ b/src/duq/_unit.py
@@ -10,20 +10,42 @@ that way; it is never silently collapsed to base SI units (use
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from fractions import Fraction
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
+from ._arraytypes import is_numpy_magnitude
 from ._dimension import Dimension, _coerce_exponent
 from ._errors import AffineUnitError, RegistryMismatchError
 from ._format import format_composition, order_terms
 
 if TYPE_CHECKING:
+    from ._quantity import Quantity
     from ._registry import UnitRegistry
 
 __all__ = ("Unit",)
 
 Scalar = Fraction | float
 """A scale or offset value: exact when a :class:`~fractions.Fraction`."""
+
+_SCALAR_NUMBERS = (int, float, complex, Fraction, Decimal)
+
+
+def _is_scalar_number(value: object) -> bool:
+    """Return whether ``value`` is a non-bool Python number a unit may scale."""
+    return not isinstance(value, bool) and isinstance(value, _SCALAR_NUMBERS)
+
+
+def _is_magnitude(value: object) -> bool:
+    """Return whether ``value`` may become a :class:`Quantity` magnitude."""
+    return _is_scalar_number(value) or is_numpy_magnitude(value)
+
+
+def _make_quantity(value: object, unit: Unit) -> Quantity:
+    """Build a :class:`Quantity` (imported lazily to avoid an import cycle)."""
+    from ._quantity import Quantity
+
+    return Quantity(value, unit)  # type: ignore[arg-type]
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,6 +129,14 @@ class Unit:
     True
     >>> duq.unit("J") == duq.unit("kg.m^2/s^2")
     True
+
+    Multiplying a unit by a number or a NumPy array scales it into a
+    :class:`~duq.Quantity` (``1 / unit`` still inverts the unit itself):
+
+    >>> (5 * duq.units.m).value
+    5
+    >>> str((1 / duq.unit("s")))
+    's⁻¹'
     """
 
     __slots__ = ("_dimension", "_factors", "_offset", "_registry", "_scale")
@@ -115,6 +145,10 @@ class Unit:
     _dimension: Dimension
     _scale: Scalar
     _offset: Scalar
+
+    #: Opt out of NumPy's ufunc machinery so ``ndarray * unit`` (and ``/``)
+    #: defers to :meth:`__rmul__`/:meth:`__rtruediv__` and yields a Quantity.
+    __array_ufunc__ = None
 
     def __init__(self) -> None:  # pragma: no cover - constructed via _create
         raise TypeError("Unit objects are created by a UnitRegistry, not directly")
@@ -213,18 +247,37 @@ class Unit:
         if other._registry is not self._registry:
             raise RegistryMismatchError("cannot combine units from different registries")
 
-    def __mul__(self, other: object) -> Unit:
-        if not isinstance(other, Unit):
-            return NotImplemented
-        self._check_registry(other)
-        return Unit._create(self._registry, self._factors + other._factors)
+    @overload
+    def __mul__(self, other: Unit) -> Unit: ...  # type: ignore[overload-overlap]
+    @overload
+    def __mul__(self, other: object) -> Quantity: ...
+    def __mul__(self, other: object) -> Unit | Quantity:
+        if isinstance(other, Unit):
+            self._check_registry(other)
+            return Unit._create(self._registry, self._factors + other._factors)
+        if _is_magnitude(other):
+            # ``unit * value`` reads as ``value * unit`` -> a Quantity.
+            return _make_quantity(other, self)
+        return NotImplemented
 
-    def __truediv__(self, other: object) -> Unit:
-        if not isinstance(other, Unit):
-            return NotImplemented
-        self._check_registry(other)
-        inverted = tuple(Factor(f.prefix, f.atom, -f.exponent) for f in other._factors)
-        return Unit._create(self._registry, self._factors + inverted)
+    def __rmul__(self, other: object) -> Quantity:
+        if _is_magnitude(other):
+            return _make_quantity(other, self)
+        return NotImplemented
+
+    @overload
+    def __truediv__(self, other: Unit) -> Unit: ...  # type: ignore[overload-overlap]
+    @overload
+    def __truediv__(self, other: object) -> Quantity: ...
+    def __truediv__(self, other: object) -> Unit | Quantity:
+        if isinstance(other, Unit):
+            self._check_registry(other)
+            inverted = tuple(Factor(f.prefix, f.atom, -f.exponent) for f in other._factors)
+            return Unit._create(self._registry, self._factors + inverted)
+        if _is_magnitude(other):
+            # ``unit / value`` is ``(1 unit) / value``.
+            return _make_quantity(1 / other, self)  # type: ignore[operator]
+        return NotImplemented
 
     def __pow__(self, power: object) -> Unit:
         try:
@@ -234,10 +287,16 @@ class Unit:
         powered = tuple(Factor(f.prefix, f.atom, f.exponent * exp) for f in self._factors)
         return Unit._create(self._registry, powered)
 
-    def __rtruediv__(self, other: object) -> Unit:
-        if other != 1:
-            return NotImplemented
-        return self**-1
+    def __rtruediv__(self, other: object) -> Unit | Quantity:
+        if is_numpy_magnitude(other):
+            # ``array / unit`` -> a Quantity carrying the inverse unit.
+            return _make_quantity(other, self**-1)
+        if _is_scalar_number(other):
+            # ``1 / unit`` inverts the unit itself; other numbers make a Quantity.
+            if other == 1:
+                return self**-1
+            return _make_quantity(other, self**-1)
+        return NotImplemented
 
     # -- equality -----------------------------------------------------------
 

--- a/tests/numpy/__init__.py
+++ b/tests/numpy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``duq._numpy`` array back-end (NEP 13 / NEP 18)."""

--- a/tests/numpy/test_arrays.py
+++ b/tests/numpy/test_arrays.py
@@ -110,10 +110,25 @@ def test_matmul_operator_and_reflected() -> None:
     assert result.unit == duq.unit("s")
 
 
-def test_bool_of_array_quantity_matches_numpy() -> None:
-    assert bool(Quantity(np.array([1.0]), "m"))
+def test_bool_of_dimensionless_array_matches_numpy() -> None:
+    # A dimensionless array quantity follows NumPy truthiness: one element
+    # coerces, more raise ValueError.
+    assert bool(Quantity(np.array([1.0]), "1"))
+    assert bool(Quantity(np.array([100.0]), "%"))
     with pytest.raises(ValueError, match="ambiguous"):
-        bool(Quantity(V, "m"))
+        bool(Quantity(V, "1"))
+    # A dimensional quantity refuses truthiness altogether.
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        bool(Quantity(np.array([1.0]), "m"))
+
+
+def test_float_of_dimensionless_array_applies_scale() -> None:
+    # 0-d arrays coerce like scalars (1-d size-1 follows NumPy's own rule,
+    # which differs between 1.26 and 2.x, so only 0-d is asserted here).
+    assert float(Quantity(np.array(50.0), "%")) == 0.5
+    assert int(Quantity(np.array(200.0), "%")) == 2
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        float(Quantity(np.array(1.0), "m"))
 
 
 @pytest.mark.parametrize(

--- a/tests/numpy/test_arrays.py
+++ b/tests/numpy/test_arrays.py
@@ -1,0 +1,161 @@
+"""Array construction, introspection, iteration, methods and the unit ergonomics."""
+
+# NumPy's type stubs cannot describe a duck array, so passing a duq.Quantity
+# to np.<func>/np.<ufunc> trips call-overload/arg-type/attr-defined; these are
+# false positives for the very dispatch these conformance tests exercise.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, dict-item"
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import duq
+from duq import Quantity
+
+V = np.array([1.0, 2.0, 3.0])
+M2 = np.arange(6.0).reshape(2, 3)
+
+
+def test_construct_stores_array_without_copy() -> None:
+    q = Quantity(V, "m")
+    assert q.is_array
+    assert q.value is V  # stored as-is, no copy
+
+
+def test_from_array_coerces_lists() -> None:
+    q = Quantity.from_array([1.0, 2.0, 3.0], "m")
+    assert q.is_array
+    assert q.shape == (3,)
+    # a bare list still cannot go through the plain constructor
+    with pytest.raises(TypeError):
+        Quantity([1.0, 2.0], "m")
+
+
+def test_numpy_scalar_is_accepted() -> None:
+    q = Quantity(np.float64(2.5), "m")
+    assert q.value == np.float64(2.5)
+
+
+def test_shape_ndim_size_dtype() -> None:
+    q = Quantity(M2, "m")
+    assert q.shape == (2, 3)
+    assert q.ndim == 2
+    assert q.size == 6
+    assert q.dtype == M2.dtype
+    # np.shape / np.ndim / np.size route through the properties
+    assert np.shape(q) == (2, 3)
+    assert np.ndim(q) == 2
+    assert np.size(q) == 6
+
+
+def test_scalar_quantity_shape_is_empty() -> None:
+    q = Quantity(2.0, "m")
+    assert q.shape == ()
+    assert q.ndim == 0
+    assert q.size == 1
+
+
+def test_len_iter_getitem_yield_quantities() -> None:
+    q = Quantity(V, "m")
+    assert len(q) == 3
+    elements = list(q)
+    assert all(isinstance(e, Quantity) and e.unit == duq.unit("m") for e in elements)
+    assert elements[0].value == 1.0
+    assert q[1].value == 2.0
+    assert q[1].unit == duq.unit("m")
+    assert q[1:].shape == (2,)
+
+
+def test_item_returns_scalar_quantity() -> None:
+    q = Quantity(np.array([[5.0]]), "m")
+    item = q.item()
+    assert isinstance(item, Quantity)
+    assert item.value == 5.0
+    assert item.unit == duq.unit("m")
+
+
+def test_len_and_iter_reject_scalar() -> None:
+    q = Quantity(2.0, "m")
+    with pytest.raises(TypeError):
+        len(q)
+    with pytest.raises(TypeError):
+        next(iter(q))
+
+
+def test_reduction_and_reshape_methods() -> None:
+    q = Quantity(V, "m")
+    assert q.sum().unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(q.sum().value), V.sum())
+    assert q.mean().unit == duq.unit("m")
+    assert q.std().unit == duq.unit("m")
+    assert q.var().unit == duq.unit("m^2")
+    assert q.min().value == 1.0
+    assert q.max().value == 3.0
+    assert q.reshape(3, 1).shape == (3, 1)
+    assert q.reshape(3, 1).unit == duq.unit("m")
+    assert q.ravel().shape == (3,)
+    assert q.astype(np.float32).dtype == np.float32
+    assert Quantity(M2, "m").T.shape == (3, 2)
+
+
+def test_matmul_operator_and_reflected() -> None:
+    a = Quantity(V, "m")
+    b = Quantity(V, "s")
+    assert (a @ b).unit == duq.unit("m*s")
+    np.testing.assert_allclose(np.asarray((a @ b).value), V @ V)
+    # ndarray @ quantity defers to __rmatmul__
+    result = V @ b
+    assert result.unit == duq.unit("s")
+
+
+def test_bool_of_array_quantity_matches_numpy() -> None:
+    assert bool(Quantity(np.array([1.0]), "m"))
+    with pytest.raises(ValueError, match="ambiguous"):
+        bool(Quantity(V, "m"))
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda u: np.linspace(0, 1, 5) * u,  # array * unit (numpy defers)
+        lambda u: u * np.linspace(0, 1, 5),  # unit * array
+    ],
+)
+def test_array_times_unit_makes_quantity(make: object) -> None:
+    q = make(duq.units.m)  # type: ignore[operator]
+    assert isinstance(q, Quantity)
+    assert q.unit == duq.unit("m")
+    assert q.shape == (5,)
+
+
+def test_array_divided_by_unit_makes_quantity() -> None:
+    q = np.arange(3.0) / duq.units.s
+    assert isinstance(q, Quantity)
+    assert q.unit == duq.unit("s^-1")
+
+
+def test_scalar_number_times_unit_makes_quantity() -> None:
+    assert isinstance(5 * duq.units.m, Quantity)
+    assert (5 * duq.units.m).value == 5
+    assert (duq.units.m * 5).value == 5
+    assert (duq.units.m / 5).value == 0.2
+    assert (10 / duq.units.s).unit == duq.unit("s^-1")
+
+
+def test_unit_array_ufunc_is_none() -> None:
+    assert duq.Unit.__array_ufunc__ is None
+
+
+def test_mixed_operand_matrix() -> None:
+    q = Quantity(V, "m")
+    # Quantity (x) ndarray  -> the ndarray is treated as dimensionless, so only a
+    # dimensionless quantity may combine additively; multiply always works.
+    assert np.multiply(q, np.array([2.0, 2.0, 2.0])).unit == duq.unit("m")
+    assert np.multiply(np.array([2.0, 2.0, 2.0]), q).unit == duq.unit("m")
+    assert (q * 2).unit == duq.unit("m")
+    # Quantity (x) Quantity with different-but-compatible units -> left convention
+    total = np.add(q, Quantity(V * 100, "cm"))
+    assert total.unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(total.value), V + V)

--- a/tests/numpy/test_coverage_numpy.py
+++ b/tests/numpy/test_coverage_numpy.py
@@ -1,0 +1,86 @@
+"""Targeted tests exercising the less-common array branches."""
+
+# NumPy's type stubs cannot describe a duck array, so passing a duq.Quantity
+# to np.<func>/np.<ufunc> trips call-overload/arg-type/attr-defined; these are
+# false positives for the very dispatch these conformance tests exercise.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, dict-item"
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import duq
+from duq import Quantity
+
+V = np.array([1.0, 2.0, 3.0])
+
+
+def test_all_array_comparison_operators() -> None:
+    a = Quantity(V, "m")
+    b = Quantity(V * 100, "cm")  # equal after conversion
+    np.testing.assert_array_equal(a == b, np.equal(V, V))
+    np.testing.assert_array_equal(a != b, np.not_equal(V, V))
+    np.testing.assert_array_equal(a <= b, V <= V)
+    np.testing.assert_array_equal(a >= b, V >= V)
+    np.testing.assert_array_equal(a > Quantity(V - 1, "m"), V > V - 1)
+    np.testing.assert_array_equal(a < Quantity(V + 1, "m"), V < V + 1)
+    # a bare array on either side still routes through the array comparison path
+    np.testing.assert_array_equal(Quantity(V, "1") == V, np.equal(V, V))
+    np.testing.assert_array_equal(V == Quantity(V, "1"), np.equal(V, V))  # noqa: SIM300
+
+
+def test_reflected_matmul_direct() -> None:
+    q = Quantity(np.eye(3), "s")
+    result = q.__rmatmul__(V)
+    assert isinstance(result, Quantity)
+    assert result.unit == duq.unit("s")
+    np.testing.assert_allclose(np.asarray(result.value), V @ np.eye(3))
+
+
+def test_where_single_arg_and_all_plain() -> None:
+    mask = Quantity(np.array([0.0, 1.0, 0.0]), "1")
+    (indices,) = np.where(mask)
+    np.testing.assert_array_equal(indices, np.where(np.array([0.0, 1.0, 0.0]))[0])
+    # cond is a Quantity but the branches are plain -> plain result
+    result = np.where(mask, np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0]))
+    assert not isinstance(result, Quantity)
+
+
+def test_average_returned_tuple() -> None:
+    q = Quantity(V, "m")
+    avg, weight_sum = np.average(q, weights=Quantity(V, "s"), returned=True)
+    assert isinstance(avg, Quantity)
+    assert avg.unit == duq.unit("m")
+    assert not isinstance(weight_sum, Quantity)
+
+
+def test_full_like_rejects_bare_fill_for_dimensional() -> None:
+    with pytest.raises(duq.DimensionalityError, match="full_like"):
+        np.full_like(Quantity(V, "m"), 2.0)
+    # a dimensionless template accepts a bare fill value
+    filled = np.full_like(Quantity(V, "1"), 2.0)
+    assert filled.unit == duq.unit("1")
+
+
+def test_same_dim_ufunc_rejects_bare_array_for_dimensional() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        np.maximum(Quantity(V, "m"), np.array([1.0, 2.0, 3.0]))
+
+
+def test_angle_convert_requires_dimensionless() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        np.deg2rad(Quantity(V, "m"))
+    # a plain array passes through unchanged (treated as raw degrees)
+    np.testing.assert_allclose(np.asarray(np.rad2deg(Quantity(V, "1")).value), np.rad2deg(V))
+
+
+def test_rsub_and_scalar_paths_still_work_for_scalars() -> None:
+    # keep the scalar reflected-subtraction path exercised alongside arrays
+    assert (Quantity(1.0, "1").__rsub__(3)).value == 2.0
+    assert (5 - Quantity(2.0, "1")).value == 3.0
+
+
+def test_dtype_of_scalar_quantity() -> None:
+    assert Quantity(2.0, "m").dtype == np.dtype("float64")

--- a/tests/numpy/test_functions.py
+++ b/tests/numpy/test_functions.py
@@ -103,7 +103,6 @@ _PRESERVE: dict[str, Callable[[], Case]] = {
     "pad": lambda: (np.pad(qv(), 1, constant_values=Quantity(0.0, "m")), np.pad(V, 1), "m"),
     "pad_edge": lambda: (np.pad(qv(), 1, mode="edge"), np.pad(V, 1, mode="edge"), "m"),
     "zeros_like": lambda: (np.zeros_like(qv()), np.zeros_like(V), "m"),
-    "empty_like": lambda: (np.zeros_like(qv()) * 0, np.zeros_like(V), "m"),
     "ones_like": lambda: (np.ones_like(qv()), np.ones_like(V), "m"),
     "full_like_quantity": lambda: (
         np.full_like(qv(), Quantity(2.0, "m")),
@@ -119,6 +118,19 @@ def test_function_preserves_unit(name: str) -> None:
     assert isinstance(result, Quantity), f"{name} must return a Quantity"
     assert result.unit == duq.unit(unit), f"{name}: {result.unit} != {unit}"
     np.testing.assert_allclose(np.asarray(result.value), expected)
+
+
+def test_creation_like_family_preserves_units() -> None:
+    q = qv()
+    for func in (np.zeros_like, np.ones_like, np.empty_like):
+        result = func(q)
+        assert isinstance(result, Quantity), func.__name__
+        assert result.unit == duq.unit("m"), func.__name__
+        assert result.shape == V.shape
+        assert result.dtype == V.dtype
+    filled = np.full_like(q, Quantity(200.0, "cm"))  # converted to the template unit
+    assert filled.unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(filled.value), np.full_like(V, 2.0))
 
 
 def test_variance_squares_the_unit() -> None:

--- a/tests/numpy/test_functions.py
+++ b/tests/numpy/test_functions.py
@@ -1,0 +1,248 @@
+"""Table-driven conformance tests for the ``__array_function__`` coverage."""
+
+# NumPy's type stubs cannot describe a duck array, so passing a duq.Quantity
+# to np.<func>/np.<ufunc> trips call-overload/arg-type/attr-defined; these are
+# false positives for the very dispatch these conformance tests exercise.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, dict-item"
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+import duq
+from duq import Quantity
+
+V = np.array([1.0, 2.0, 3.0, 4.0])
+W = np.array([10.0, 20.0, 30.0, 40.0])
+M2 = np.arange(6.0).reshape(2, 3)
+
+
+def qv(values: np.ndarray = V, unit: str = "m") -> Quantity:
+    return Quantity(values, unit)
+
+
+# name -> (duq result, expected raw magnitude, expected unit str)
+Case = tuple[object, object, str]
+_PRESERVE: dict[str, Callable[[], Case]] = {
+    "reshape": lambda: (np.reshape(qv(), (2, 2)), V.reshape(2, 2), "m"),
+    "ravel": lambda: (np.ravel(qv(M2)), M2.ravel(), "m"),
+    "transpose": lambda: (np.transpose(qv(M2)), M2.T, "m"),
+    "swapaxes": lambda: (np.swapaxes(qv(M2), 0, 1), np.swapaxes(M2, 0, 1), "m"),
+    "moveaxis": lambda: (np.moveaxis(qv(M2), 0, 1), np.moveaxis(M2, 0, 1), "m"),
+    "squeeze": lambda: (np.squeeze(qv(V.reshape(1, 4))), V, "m"),
+    "expand_dims": lambda: (np.expand_dims(qv(), 0), V.reshape(1, 4), "m"),
+    "broadcast_to": lambda: (np.broadcast_to(qv(), (2, 4)), np.broadcast_to(V, (2, 4)), "m"),
+    "flip": lambda: (np.flip(qv()), np.flip(V), "m"),
+    "fliplr": lambda: (np.fliplr(qv(M2)), np.fliplr(M2), "m"),
+    "flipud": lambda: (np.flipud(qv(M2)), np.flipud(M2), "m"),
+    "roll": lambda: (np.roll(qv(), 1), np.roll(V, 1), "m"),
+    "rot90": lambda: (np.rot90(qv(M2)), np.rot90(M2), "m"),
+    "tile": lambda: (np.tile(qv(), 2), np.tile(V, 2), "m"),
+    "repeat": lambda: (np.repeat(qv(), 2), np.repeat(V, 2), "m"),
+    "delete": lambda: (np.delete(qv(), 0), np.delete(V, 0), "m"),
+    "take": lambda: (np.take(qv(), [0, 2]), np.take(V, [0, 2]), "m"),
+    "diagonal": lambda: (np.diagonal(qv(M2)), np.diagonal(M2), "m"),
+    "diag": lambda: (np.diag(qv()), np.diag(V), "m"),
+    "real": lambda: (np.real(qv()), V, "m"),
+    "imag": lambda: (np.imag(qv()), np.zeros_like(V), "m"),
+    "copy": lambda: (np.copy(qv()), V, "m"),
+    "sort": lambda: (np.sort(qv(np.array([3.0, 1.0, 2.0]))), np.array([1.0, 2.0, 3.0]), "m"),
+    "cumsum": lambda: (np.cumsum(qv()), np.cumsum(V), "m"),
+    "nancumsum": lambda: (np.nancumsum(qv()), np.nancumsum(V), "m"),
+    "diff": lambda: (np.diff(qv()), np.diff(V), "m"),
+    "ediff1d": lambda: (np.ediff1d(qv()), np.ediff1d(V), "m"),
+    "sum": lambda: (np.sum(qv()), V.sum(), "m"),
+    "nansum": lambda: (np.nansum(qv()), np.nansum(V), "m"),
+    "mean": lambda: (np.mean(qv()), V.mean(), "m"),
+    "nanmean": lambda: (np.nanmean(qv()), np.nanmean(V), "m"),
+    "median": lambda: (np.median(qv()), np.median(V), "m"),
+    "nanmedian": lambda: (np.nanmedian(qv()), np.nanmedian(V), "m"),
+    "min": lambda: (np.min(qv()), V.min(), "m"),
+    "max": lambda: (np.max(qv()), V.max(), "m"),
+    "amin": lambda: (np.amin(qv()), V.min(), "m"),
+    "amax": lambda: (np.amax(qv()), V.max(), "m"),
+    "nanmin": lambda: (np.nanmin(qv()), np.nanmin(V), "m"),
+    "nanmax": lambda: (np.nanmax(qv()), np.nanmax(V), "m"),
+    "ptp": lambda: (np.ptp(qv()), np.ptp(V), "m"),
+    "std": lambda: (np.std(qv()), V.std(), "m"),
+    "nanstd": lambda: (np.nanstd(qv()), np.nanstd(V), "m"),
+    "trace": lambda: (np.trace(qv(M2)), np.trace(M2), "m"),
+    "around": lambda: (np.around(qv(np.array([1.24, 2.55])), 1), np.array([1.2, 2.6]), "m"),
+    "round": lambda: (np.round(qv(np.array([1.4, 2.6]))), np.array([1.0, 3.0]), "m"),
+    "quantile": lambda: (np.quantile(qv(), 0.5), np.quantile(V, 0.5), "m"),
+    "percentile": lambda: (np.percentile(qv(), 50), np.percentile(V, 50), "m"),
+    "norm": lambda: (np.linalg.norm(qv()), np.linalg.norm(V), "m"),
+    "average": lambda: (np.average(qv()), np.average(V), "m"),
+    "average_weighted": lambda: (
+        np.average(qv(), weights=Quantity(W, "s")),
+        np.average(V, weights=W),
+        "m",
+    ),
+    "clip": lambda: (
+        np.clip(qv(), Quantity(1.5, "m"), Quantity(3.5, "m")),
+        np.clip(V, 1.5, 3.5),
+        "m",
+    ),
+    "compress": lambda: (
+        np.compress(np.array([True, False, True, False]), qv()),
+        np.compress([True, False, True, False], V),
+        "m",
+    ),
+    "append": lambda: (np.append(qv(), Quantity(np.array([500.0]), "cm")), np.append(V, 5.0), "m"),
+    "insert": lambda: (np.insert(qv(), 0, Quantity(0.5, "m")), np.insert(V, 0, 0.5), "m"),
+    "where": lambda: (
+        np.where(V > 2, qv(), Quantity(W, "m")),
+        np.where(V > 2, V, W),
+        "m",
+    ),
+    "unique": lambda: (np.unique(qv(np.array([2.0, 1.0, 2.0]))), np.array([1.0, 2.0]), "m"),
+    "pad": lambda: (np.pad(qv(), 1, constant_values=Quantity(0.0, "m")), np.pad(V, 1), "m"),
+    "pad_edge": lambda: (np.pad(qv(), 1, mode="edge"), np.pad(V, 1, mode="edge"), "m"),
+    "zeros_like": lambda: (np.zeros_like(qv()), np.zeros_like(V), "m"),
+    "empty_like": lambda: (np.zeros_like(qv()) * 0, np.zeros_like(V), "m"),
+    "ones_like": lambda: (np.ones_like(qv()), np.ones_like(V), "m"),
+    "full_like_quantity": lambda: (
+        np.full_like(qv(), Quantity(2.0, "m")),
+        np.full_like(V, 2.0),
+        "m",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", list(_PRESERVE))
+def test_function_preserves_unit(name: str) -> None:
+    result, expected, unit = _PRESERVE[name]()
+    assert isinstance(result, Quantity), f"{name} must return a Quantity"
+    assert result.unit == duq.unit(unit), f"{name}: {result.unit} != {unit}"
+    np.testing.assert_allclose(np.asarray(result.value), expected)
+
+
+def test_variance_squares_the_unit() -> None:
+    assert np.var(qv()).unit == duq.unit("m^2")
+    np.testing.assert_allclose(np.asarray(np.var(qv()).value), V.var())
+    assert np.nanvar(qv()).unit == duq.unit("m^2")
+
+
+def test_products_multiply_units() -> None:
+    a, b = qv(V, "m"), qv(W, "s")
+    assert np.dot(a, b).unit == duq.unit("m*s")
+    np.testing.assert_allclose(np.asarray(np.dot(a, b).value), V @ W)
+    assert np.inner(a, b).unit == duq.unit("m*s")
+    assert np.vdot(a, b).unit == duq.unit("m*s")
+    assert np.outer(a, b).unit == duq.unit("m*s")
+    assert np.kron(a, b).unit == duq.unit("m*s")
+    assert np.tensordot(a, b, axes=1).unit == duq.unit("m*s")
+    cross = np.cross(qv(np.array([1.0, 0.0, 0.0]), "m"), qv(np.array([0.0, 1.0, 0.0]), "s"))
+    assert cross.unit == duq.unit("m*s")
+
+
+def test_einsum_multiplies_units() -> None:
+    a, b = qv(V, "m"), qv(W, "s")
+    result = np.einsum("i,i->", a, b)
+    assert result.unit == duq.unit("m*s")
+    np.testing.assert_allclose(np.asarray(result.value), np.einsum("i,i->", V, W))
+
+
+@pytest.mark.parametrize(
+    "func", [np.concatenate, np.stack, np.hstack, np.vstack, np.dstack, np.column_stack]
+)
+def test_joining_converts_to_first_unit(func: object) -> None:
+    a = qv(V, "m")
+    b = Quantity(W * 100, "cm")  # same dimension, different unit
+    result = func([a, b])  # type: ignore[operator]
+    assert isinstance(result, Quantity)
+    assert result.unit == duq.unit("m")
+
+
+def test_split_family_returns_list_of_quantities() -> None:
+    q = qv(V, "m")
+    parts = np.split(q, 2)
+    assert all(isinstance(p, Quantity) and p.unit == duq.unit("m") for p in parts)
+    assert all(isinstance(p, Quantity) for p in np.array_split(q, 3))
+
+
+def test_atleast_and_broadcast_arrays() -> None:
+    q = qv(V, "m")
+    assert np.atleast_2d(q).unit == duq.unit("m")
+    one, two = np.atleast_1d(q, Quantity(np.array([1.0]), "s"))
+    assert one.unit == duq.unit("m")
+    assert two.unit == duq.unit("s")
+    b1, b2 = np.broadcast_arrays(qv(np.array([[1.0], [2.0]]), "m"), Quantity(V, "s"))
+    assert b1.unit == duq.unit("m")
+    assert b2.unit == duq.unit("s")
+
+
+def test_search_and_index_functions_return_plain() -> None:
+    q = qv(np.array([1.0, 3.0, 2.0]), "m")
+    assert not isinstance(np.argmin(q), Quantity)
+    assert not isinstance(np.argsort(q), Quantity)
+    assert not isinstance(np.count_nonzero(q), Quantity)
+    # searchsorted / digitize convert the query to the array unit
+    sorted_q = qv(V, "m")
+    idx = np.searchsorted(sorted_q, Quantity(250.0, "cm"))
+    assert int(idx) == np.searchsorted(V, 2.5)
+    bins = np.digitize(qv(np.array([2.5]), "m"), Quantity(V, "m"))
+    np.testing.assert_array_equal(bins, np.digitize([2.5], V))
+
+
+def test_interp_converts_x_preserves_fp_unit() -> None:
+    x = Quantity(np.array([150.0]), "cm")  # 1.5 m
+    xp = qv(V, "m")
+    fp = Quantity(W, "s")
+    result = np.interp(x, xp, fp)
+    assert result.unit == duq.unit("s")
+    np.testing.assert_allclose(np.asarray(result.value), np.interp([1.5], V, W))
+
+
+def test_meshgrid_preserves_each_unit() -> None:
+    gx, gy = np.meshgrid(qv(V, "m"), Quantity(W, "s"))
+    assert gx.unit == duq.unit("m")
+    assert gy.unit == duq.unit("s")
+
+
+def test_histogram_returns_plain_counts_and_edge_quantity() -> None:
+    counts, edges = np.histogram(qv(V, "m"), bins=Quantity(np.array([0.0, 2.0, 4.0]), "m"))
+    assert not isinstance(counts, Quantity)
+    assert isinstance(edges, Quantity)
+    assert edges.unit == duq.unit("m")
+
+
+def test_gradient_divides_units() -> None:
+    f = Quantity(V**2, "m")
+    x = Quantity(V, "s")
+    grad = np.gradient(f, x)
+    assert grad.unit == duq.unit("m/s")
+    np.testing.assert_allclose(np.asarray(grad.value), np.gradient(V**2, V))
+    # No spacing -> unit preserved.
+    assert np.gradient(f).unit == duq.unit("m")
+
+
+def test_trapezoid_multiplies_units() -> None:
+    trapezoid = getattr(np, "trapezoid", None) or np.trapz  # numpy>=2 vs 1.26
+    y = Quantity(V, "m")
+    x = Quantity(W, "s")
+    result = trapezoid(y, x=x)
+    assert result.unit == duq.unit("m*s")
+    result_dx = trapezoid(y, dx=Quantity(2.0, "s"))
+    assert result_dx.unit == duq.unit("m*s")
+
+
+def test_allclose_and_isclose_unit_aware() -> None:
+    a = qv(V, "m")
+    b = Quantity(V * 100, "cm")
+    assert np.allclose(a, b, atol=Quantity(1e-9, "m"))
+    close = np.isclose(a, b, atol=Quantity(1e-9, "m"))
+    assert close.dtype == np.bool_
+    assert bool(close.all())
+    # dimensionless arrays may use the default tolerances
+    assert np.allclose(Quantity(V, "1"), Quantity(V, "1"))
+
+
+def test_array_equal_and_equiv() -> None:
+    assert np.array_equal(qv(V, "m"), Quantity(V * 100, "cm"))
+    assert not np.array_equal(qv(V, "m"), Quantity(V, "s"))  # incompatible -> False
+    assert np.array_equiv(qv(V, "m"), Quantity(V * 100, "cm"))

--- a/tests/numpy/test_guards.py
+++ b/tests/numpy/test_guards.py
@@ -27,7 +27,7 @@ def test_array_and_asarray_never_strip_units() -> None:
         q.__array__()
 
 
-def test_scalar_coercions_fail_loud() -> None:
+def test_scalar_coercions_fail_loud_for_dimensional() -> None:
     q = Quantity(2.0, "m")
     with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
         float(q)
@@ -35,6 +35,10 @@ def test_scalar_coercions_fail_loud() -> None:
         int(q)
     with pytest.raises(duq.UnsupportedOperationError):
         complex(q)
+    with pytest.raises(duq.UnsupportedOperationError):
+        bool(q)
+    # Dimensionless quantities coerce, applying the unit scale (pint-consistent).
+    assert float(Quantity(50.0, "%")) == 0.5
 
 
 def test_unsupported_ufunc_names_the_function() -> None:
@@ -84,10 +88,22 @@ def test_power_rejects_nonuniform_array_exponent() -> None:
 def test_allclose_requires_quantity_atol_for_dimensional() -> None:
     a = Quantity(V, "m")
     b = Quantity(V, "m")
+    # The default atol=1e-8 would silently assume the base-unit scale (wrong
+    # for e.g. km), so a dimensional comparison demands an explicit Quantity atol.
     with pytest.raises(duq.DimensionalityError, match="atol"):
-        np.allclose(a, b)  # default atol is meaningless for a dimensional array
+        np.allclose(a, b)
     with pytest.raises(duq.DimensionalityError, match="atol"):
-        np.allclose(a, b, atol=1e-9)  # bare atol rejected too
+        np.allclose(a, b, atol=1e-9)  # bare float atol rejected too
+    with pytest.raises(duq.DimensionalityError, match="atol"):
+        np.isclose(a, b)
+    with pytest.raises(duq.DimensionalityError, match="atol"):
+        np.isclose(a, b, atol=1e-9)
+    # A Quantity atol converts and works, whatever its (compatible) unit.
+    km = Quantity(V / 1000.0, "km")
+    assert np.allclose(a, km, atol=Quantity(1e-6, "mm"))
+    assert bool(np.isclose(a, km, atol=Quantity(1e-6, "mm")).all())
+    with pytest.raises(duq.DimensionalityError):
+        np.allclose(a, b, atol=Quantity(1e-9, "s"))  # wrong-dimension atol
 
 
 def test_incompatible_dimensions_raise() -> None:

--- a/tests/numpy/test_guards.py
+++ b/tests/numpy/test_guards.py
@@ -1,0 +1,148 @@
+"""Fail-loud guards: silent-strip holes, unsupported ops, and the affine policy."""
+
+# NumPy's type stubs cannot describe a duck array, so passing a duq.Quantity
+# to np.<func>/np.<ufunc> trips call-overload/arg-type/attr-defined; these are
+# false positives for the very dispatch these conformance tests exercise.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, dict-item"
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import duq
+from duq import Quantity
+
+V = np.array([1.0, 2.0, 3.0])
+
+
+def test_array_and_asarray_never_strip_units() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        np.array(q)
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        np.asarray(q)
+    with pytest.raises(duq.UnsupportedOperationError):
+        q.__array__()
+
+
+def test_scalar_coercions_fail_loud() -> None:
+    q = Quantity(2.0, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        float(q)
+    with pytest.raises(duq.UnsupportedOperationError):
+        int(q)
+    with pytest.raises(duq.UnsupportedOperationError):
+        complex(q)
+
+
+def test_unsupported_ufunc_names_the_function() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="heaviside"):
+        np.heaviside(q, 0.5)
+
+
+def test_unsupported_function_names_the_function() -> None:
+    q = Quantity(np.eye(2), "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="inv"):
+        np.linalg.inv(q)
+    with pytest.raises(duq.UnsupportedOperationError):
+        np.linalg.det(q)
+
+
+def test_out_argument_is_rejected() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="out="):
+        np.add(q, q, out=np.empty(3))
+
+
+def test_multiply_reduce_is_rejected_with_guidance() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="prod"):
+        np.multiply.reduce(q)
+
+
+def test_unsupported_ufunc_method_is_rejected() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError):
+        np.add.outer(q, q)
+
+
+def test_pad_unsupported_mode_is_rejected() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="mode"):
+        np.pad(q, 1, mode="linear_ramp")
+
+
+def test_power_rejects_nonuniform_array_exponent() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="exponent"):
+        np.power(q, np.array([1.0, 2.0, 3.0]))
+
+
+def test_allclose_requires_quantity_atol_for_dimensional() -> None:
+    a = Quantity(V, "m")
+    b = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError, match="atol"):
+        np.allclose(a, b)  # default atol is meaningless for a dimensional array
+    with pytest.raises(duq.DimensionalityError, match="atol"):
+        np.allclose(a, b, atol=1e-9)  # bare atol rejected too
+
+
+def test_incompatible_dimensions_raise() -> None:
+    a = Quantity(V, "m")
+    b = Quantity(V, "s")
+    with pytest.raises(duq.DimensionalityError):
+        np.add(a, b)
+    with pytest.raises(duq.DimensionalityError):
+        np.concatenate([a, b])
+    with pytest.raises(duq.DimensionalityError):
+        _ = a < b
+
+
+def test_equal_on_incompatible_dims_is_all_false() -> None:
+    a = Quantity(V, "m")
+    b = Quantity(V, "s")
+    eq = np.equal(a, b)
+    assert isinstance(eq, np.ndarray)
+    assert not eq.any()
+    ne = np.not_equal(a, b)
+    assert ne.all()
+
+
+def test_bare_number_with_dimensional_array_rejected() -> None:
+    a = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError):
+        np.add(a, 2.0)
+    with pytest.raises(duq.DimensionalityError):
+        _ = a + np.array([1.0, 2.0, 3.0])
+
+
+def test_celsius_array_converts_but_arithmetic_follows_affine_policy() -> None:
+    celsius = Quantity(np.array([0.0, 100.0]), "degC")
+    np.testing.assert_allclose(np.asarray(celsius.to("K").value), [273.15, 373.15])
+    with pytest.raises(duq.AffineUnitError):
+        celsius + celsius
+    with pytest.raises(duq.AffineUnitError):
+        np.multiply(celsius, 2.0)
+    with pytest.raises(duq.AffineUnitError):
+        np.negative(celsius)
+    # °C - °C is a difference in kelvin (per the scalar affine policy).
+    diff = celsius - Quantity(np.array([0.0, 50.0]), "degC")
+    assert diff.unit == duq.unit("K")
+
+
+def test_dimensionless_function_requires_dimensionless() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        np.exp(Quantity(V, "m"))
+    with pytest.raises(duq.DimensionalityError):
+        np.sin(Quantity(V, "m"))
+
+
+def test_compact_and_allclose_reject_array_magnitudes() -> None:
+    q = Quantity(V, "m")
+    with pytest.raises(duq.UnsupportedOperationError):
+        q.compact()
+    with pytest.raises(duq.UnsupportedOperationError):
+        q.allclose(q)

--- a/tests/numpy/test_ufuncs.py
+++ b/tests/numpy/test_ufuncs.py
@@ -1,0 +1,205 @@
+"""Table-driven conformance tests for every covered ufunc.
+
+Each case computes the duq result and the raw-NumPy reference on the *stripped*
+magnitudes, then asserts both equal magnitudes and the expected output unit
+(or a plain, unit-free ndarray where that is the rule).
+"""
+
+# NumPy's type stubs cannot describe a duck array, so passing a duq.Quantity
+# to np.<func>/np.<ufunc> trips call-overload/arg-type/attr-defined; these are
+# false positives for the very dispatch these conformance tests exercise.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, dict-item"
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+import duq
+from duq import Quantity
+
+P = np.array([1.0, 2.0, 3.0])
+Q = np.array([2.0, 5.0, 7.0])
+R = np.array([0.25, 0.5, 0.75])  # inside (-1, 1) for the inverse trig domain
+
+
+def qm(values: np.ndarray = P) -> Quantity:
+    return Quantity(values, "m")
+
+
+def qs(values: np.ndarray = Q) -> Quantity:
+    return Quantity(values, "s")
+
+
+# id -> (duq result, expected raw magnitude, expected unit str or None-for-plain)
+Case = tuple[object, np.ndarray, str | None]
+_CASES: dict[str, Callable[[], Case]] = {
+    # multiplicative
+    "multiply": lambda: (np.multiply(qm(), qs()), P * Q, "m*s"),
+    "matmul": lambda: (np.matmul(qm(), qs()), P @ Q, "m*s"),
+    "divide": lambda: (np.divide(qm(), qs()), P / Q, "m/s"),
+    "true_divide": lambda: (np.true_divide(qm(), qs()), P / Q, "m/s"),
+    "floor_divide": lambda: (np.floor_divide(qm(Q), qs(P)), Q // P, "m/s"),
+    # additive / same-dimension (right operand converted to the left unit)
+    "add": lambda: (np.add(qm(), qm(Q)), P + Q, "m"),
+    "add_convert": lambda: (np.add(qm(), Quantity(Q * 100, "cm")), P + Q, "m"),
+    "subtract": lambda: (np.subtract(qm(Q), qm(P)), Q - P, "m"),
+    "hypot": lambda: (np.hypot(qm(np.array([3.0])), qm(np.array([4.0]))), np.array([5.0]), "m"),
+    "maximum": lambda: (np.maximum(qm(), qm(Q)), np.maximum(P, Q), "m"),
+    "minimum": lambda: (np.minimum(qm(), qm(Q)), np.minimum(P, Q), "m"),
+    "fmax": lambda: (np.fmax(qm(), qm(Q)), np.fmax(P, Q), "m"),
+    "fmin": lambda: (np.fmin(qm(), qm(Q)), np.fmin(P, Q), "m"),
+    "remainder": lambda: (np.remainder(qm(Q), qm(P)), np.remainder(Q, P), "m"),
+    "mod": lambda: (np.mod(qm(Q), qm(P)), np.mod(Q, P), "m"),
+    "fmod": lambda: (np.fmod(qm(Q), qm(P)), np.fmod(Q, P), "m"),
+    "nextafter": lambda: (np.nextafter(qm(), qm(Q)), np.nextafter(P, Q), "m"),
+    "copysign": lambda: (np.copysign(qm(), qm(-Q)), np.copysign(P, -Q), "m"),
+    # powers
+    "power": lambda: (np.power(qm(), 2), P**2, "m^2"),
+    "float_power": lambda: (np.float_power(qm(), 2), P**2.0, "m^2"),
+    "sqrt": lambda: (np.sqrt(Quantity(P**2, "m^2")), P, "m"),
+    "cbrt": lambda: (np.cbrt(Quantity(P**3, "m^3")), P, "m"),
+    "square": lambda: (np.square(qm()), P**2, "m^2"),
+    "reciprocal": lambda: (np.reciprocal(qm()), 1 / P, "m^-1"),
+    # unary preserving
+    "negative": lambda: (np.negative(qm()), -P, "m"),
+    "positive": lambda: (np.positive(qm()), P, "m"),
+    "absolute": lambda: (np.absolute(qm(-P)), P, "m"),
+    "fabs": lambda: (np.fabs(qm(-P)), P, "m"),
+    "conjugate": lambda: (np.conjugate(qm()), P, "m"),
+    "floor": lambda: (np.floor(qm(np.array([1.7]))), np.array([1.0]), "m"),
+    "ceil": lambda: (np.ceil(qm(np.array([1.2]))), np.array([2.0]), "m"),
+    "trunc": lambda: (np.trunc(qm(np.array([1.7]))), np.array([1.0]), "m"),
+    "rint": lambda: (np.rint(qm(np.array([1.5, 2.5]))), np.array([2.0, 2.0]), "m"),
+    # plain (unit-free) unary
+    "sign": lambda: (np.sign(qm(np.array([-2.0, 0.0, 3.0]))), np.array([-1.0, 0.0, 1.0]), None),
+    "isfinite": lambda: (np.isfinite(qm()), np.array([True, True, True]), None),
+    "isnan": lambda: (np.isnan(qm()), np.array([False, False, False]), None),
+    "isinf": lambda: (np.isinf(qm()), np.array([False, False, False]), None),
+    "signbit": lambda: (np.signbit(qm(-P)), np.array([True, True, True]), None),
+    # dimensionless-in, dimensionless-out
+    "exp": lambda: (np.exp(Quantity(R, "1")), np.exp(R), "1"),
+    "exp2": lambda: (np.exp2(Quantity(R, "1")), np.exp2(R), "1"),
+    "expm1": lambda: (np.expm1(Quantity(R, "1")), np.expm1(R), "1"),
+    "log": lambda: (np.log(Quantity(P, "1")), np.log(P), "1"),
+    "log2": lambda: (np.log2(Quantity(P, "1")), np.log2(P), "1"),
+    "log10": lambda: (np.log10(Quantity(P, "1")), np.log10(P), "1"),
+    "log1p": lambda: (np.log1p(Quantity(R, "1")), np.log1p(R), "1"),
+    "sinh": lambda: (np.sinh(Quantity(R, "1")), np.sinh(R), "1"),
+    "cosh": lambda: (np.cosh(Quantity(R, "1")), np.cosh(R), "1"),
+    "tanh": lambda: (np.tanh(Quantity(R, "1")), np.tanh(R), "1"),
+    "arcsinh": lambda: (np.arcsinh(Quantity(R, "1")), np.arcsinh(R), "1"),
+    "arccosh": lambda: (np.arccosh(Quantity(P, "1")), np.arccosh(P), "1"),
+    "arctanh": lambda: (np.arctanh(Quantity(R, "1")), np.arctanh(R), "1"),
+    "logaddexp": lambda: (
+        np.logaddexp(Quantity(R, "1"), Quantity(P, "1")),
+        np.logaddexp(R, P),
+        "1",
+    ),
+    "logaddexp2": lambda: (
+        np.logaddexp2(Quantity(R, "1"), Quantity(P, "1")),
+        np.logaddexp2(R, P),
+        "1",
+    ),
+    # percent is a scaled dimensionless unit: 50 % -> 0.5 before exp
+    "exp_percent": lambda: (np.exp(Quantity(np.array([50.0]), "%")), np.exp(np.array([0.5])), "1"),
+    # angle-in (radian or degree), dimensionless out
+    "sin_rad": lambda: (
+        np.sin(Quantity(np.array([0.0, np.pi / 2]), "rad")),
+        np.sin(np.array([0.0, np.pi / 2])),
+        "1",
+    ),
+    "cos_deg": lambda: (
+        np.cos(Quantity(np.array([0.0, 180.0]), "deg")),
+        np.array([1.0, -1.0]),
+        "1",
+    ),
+    "tan_rad": lambda: (np.tan(Quantity(R, "rad")), np.tan(R), "1"),
+    # inverse trig -> radian-labelled
+    "arcsin": lambda: (np.arcsin(Quantity(R, "1")), np.arcsin(R), "rad"),
+    "arccos": lambda: (np.arccos(Quantity(R, "1")), np.arccos(R), "rad"),
+    "arctan": lambda: (np.arctan(Quantity(P, "1")), np.arctan(P), "rad"),
+    "arctan2": lambda: (np.arctan2(qm(), qm(Q)), np.arctan2(P, Q), "rad"),
+    # angle conversion ufuncs
+    "deg2rad": lambda: (np.deg2rad(Quantity(np.array([90.0]), "deg")), np.deg2rad([90.0]), "rad"),
+    "radians": lambda: (np.radians(Quantity(np.array([90.0]), "deg")), np.radians([90.0]), "rad"),
+    "rad2deg": lambda: (
+        np.rad2deg(Quantity(np.array([np.pi]), "rad")),
+        np.rad2deg([np.pi]),
+        "deg",
+    ),
+    "degrees": lambda: (
+        np.degrees(Quantity(np.array([np.pi]), "rad")),
+        np.degrees([np.pi]),
+        "deg",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", list(_CASES))
+def test_ufunc_conformance(name: str) -> None:
+    result, expected, unit = _CASES[name]()
+    if unit is None:
+        assert not isinstance(result, Quantity), f"{name} must return a plain ndarray"
+        np.testing.assert_allclose(np.asarray(result), expected)
+    else:
+        assert isinstance(result, Quantity), f"{name} must return a Quantity"
+        assert result.unit == duq.unit(unit), f"{name}: {result.unit} != {unit}"
+        np.testing.assert_allclose(np.asarray(result.value), expected)
+
+
+_COMPARISONS = {
+    "equal": (np.equal, lambda a, b: a == b),
+    "not_equal": (np.not_equal, lambda a, b: a != b),
+    "less": (np.less, lambda a, b: a < b),
+    "less_equal": (np.less_equal, lambda a, b: a <= b),
+    "greater": (np.greater, lambda a, b: a > b),
+    "greater_equal": (np.greater_equal, lambda a, b: a >= b),
+}
+
+
+@pytest.mark.parametrize("name", list(_COMPARISONS))
+def test_comparison_ufuncs_return_plain_bool(name: str) -> None:
+    ufunc, ref = _COMPARISONS[name]
+    left = Quantity(P, "m")
+    right = Quantity(Q * 100, "cm")  # different unit, same dimension -> converted
+    result = ufunc(left, right)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.bool_
+    np.testing.assert_array_equal(result, ref(P, Q))
+
+
+def test_comparison_reflected_operator_matches_ufunc() -> None:
+    left = Quantity(P, "m")
+    right = Quantity(Q, "m")
+    np.testing.assert_array_equal(left < right, np.less(left, right))
+    np.testing.assert_array_equal(left == right, np.equal(left, right))
+
+
+def test_reduce_and_accumulate_preserve_units() -> None:
+    q = Quantity(P, "m")
+    assert np.add.reduce(q).unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(np.add.reduce(q).value), P.sum())
+    assert np.maximum.reduce(q).unit == duq.unit("m")
+    assert np.minimum.reduce(q).unit == duq.unit("m")
+    acc = np.add.accumulate(q)
+    assert acc.unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(acc.value), np.add.accumulate(P))
+
+
+def test_power_accepts_uniform_array_exponent() -> None:
+    q = Quantity(P, "m")
+    result = np.power(q, np.array([2.0, 2.0, 2.0]))
+    assert result.unit == duq.unit("m^2")
+    np.testing.assert_allclose(np.asarray(result.value), P**2)
+
+
+def test_scalar_boxing_from_0d_and_numpy_scalar() -> None:
+    q = Quantity(np.float64(2.0), "m")
+    assert isinstance(np.negative(q), Quantity)
+    zero_d = Quantity(np.array(3.0), "m")
+    assert np.sqrt(Quantity(np.array(4.0), "m^2")).unit == duq.unit("m")
+    assert zero_d.ndim == 0

--- a/tests/numpy/test_ufuncs.py
+++ b/tests/numpy/test_ufuncs.py
@@ -190,6 +190,15 @@ def test_reduce_and_accumulate_preserve_units() -> None:
     np.testing.assert_allclose(np.asarray(acc.value), np.add.accumulate(P))
 
 
+def test_power_scalar_and_0d_exponents() -> None:
+    q = Quantity(P, "m")
+    for exponent in (2, 2.0, np.array(2.0), np.float64(2.0), Quantity(np.array(2.0), "1")):
+        result = np.power(q, exponent)
+        assert isinstance(result, Quantity), repr(exponent)
+        assert result.unit == duq.unit("m^2"), repr(exponent)
+        np.testing.assert_allclose(np.asarray(result.value), P**2)
+
+
 def test_power_accepts_uniform_array_exponent() -> None:
     q = Quantity(P, "m")
     result = np.power(q, np.array([2.0, 2.0, 2.0]))

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -257,12 +257,13 @@ def test_uconvert_ustrip() -> None:
     assert duq.ustrip("cm", Quantity(1.0, "m")) == 100.0
 
 
-def test_array_hooks_raise() -> None:
+def test_array_hooks_raise_for_unsupported() -> None:
     q = Quantity(1.0, "m")
+    # An unknown ufunc / function has no registered unit rule and must fail loud.
     with pytest.raises(duq.UnsupportedOperationError):
-        q.__array_ufunc__(None, "__call__")
+        q.__array_ufunc__(object(), "__call__", q)
     with pytest.raises(duq.UnsupportedOperationError):
-        q.__array_function__(None, (), (), {})
+        q.__array_function__(len, (), (q,), {})
 
 
 @given(q=sd.quantities(), unit=sd.units())

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from decimal import Decimal
 from fractions import Fraction
 
@@ -255,6 +256,37 @@ def test_repr_and_str() -> None:
 def test_uconvert_ustrip() -> None:
     assert duq.uconvert("cm", Quantity(1.0, "m")).value == 100.0
     assert duq.ustrip("cm", Quantity(1.0, "m")) == 100.0
+
+
+def test_dimensionless_scalar_coercions_apply_scale() -> None:
+    # A dimensionless quantity has an unambiguous numeric value once the unit
+    # scale is applied (pint-consistent).
+    assert float(Quantity(0.5, "1")) == 0.5
+    assert float(Quantity(50.0, "%")) == 0.5
+    assert int(Quantity(200.0, "%")) == 2
+    assert float(Quantity(2.0, "ppm")) == 2e-6
+    assert complex(Quantity(50.0, "%")) == 0.5 + 0j
+    # Angle-labelled units are dimensionless in duq's dimension system.
+    assert float(Quantity(1.5, "rad")) == 1.5
+    assert float(Quantity(90.0, "deg")) == pytest.approx(math.pi / 2)
+
+
+def test_dimensionless_bool_follows_magnitude() -> None:
+    assert bool(Quantity(50.0, "%")) is True
+    assert bool(Quantity(0.0, "1")) is False
+    assert bool(Quantity(0.0, "%")) is False
+
+
+def test_dimensional_scalar_coercions_fail_loud() -> None:
+    q = Quantity(2.0, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        float(q)
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        int(q)
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        complex(q)
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        bool(q)
 
 
 def test_array_hooks_raise_for_unsupported() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -41,8 +41,13 @@ def test_reciprocal() -> None:
     assert (1 / duq.unit("s")) == duq.unit("Hz")
 
 
-def test_reciprocal_only_one() -> None:
-    assert duq.unit("s").__rtruediv__(2) is NotImplemented
+def test_reciprocal_one_is_a_unit_other_numbers_a_quantity() -> None:
+    # ``1 / unit`` inverts the unit itself; other numbers scale it into a Quantity.
+    assert isinstance(1 / duq.unit("s"), duq.Unit)
+    two_over_s = duq.unit("s").__rtruediv__(2)
+    assert isinstance(two_over_s, duq.Quantity)
+    assert two_over_s.value == 2
+    assert two_over_s.unit == duq.unit("s^-1")
 
 
 def test_power_and_pow_type_guard() -> None:
@@ -80,9 +85,11 @@ def test_repr() -> None:
 
 
 def test_dunder_notimplemented_for_foreign() -> None:
-    assert duq.unit("m").__mul__(3) is NotImplemented
+    assert duq.unit("m").__mul__("x") is NotImplemented
     assert duq.unit("m").__truediv__("x") is NotImplemented
     assert duq.unit("m").__eq__(3) is NotImplemented
+    # A bool is rejected (it is not a magnitude), like elsewhere in duq.
+    assert duq.unit("m").__mul__(True) is NotImplemented
 
 
 @pytest.mark.parametrize("expression", ["degC^2", "degC.s", "degC^-1", "°C.mol"])


### PR DESCRIPTION
## Summary

PR 3 of the v1 overhaul: unit-carrying **NumPy** arrays on the existing
`duq.Quantity`, using the wrapper approach (never an `ndarray` subclass) with
`__array_ufunc__` (NEP 13) + `__array_function__` (NEP 18). All NumPy glue lives
in a new **`src/duq/_numpy/`** package that is imported **lazily** — only from
`Quantity`'s array hooks and array helpers — so `import duq` and every scalar
operation stay NumPy-free (the PR 2 no-numpy-import meta test still passes).

Dispatch is driven by the core `duq._rules` engine, so the *physics* of
dimensional analysis is written once and shared with the (future) JAX front-end.
Everything **fails loud**: an unhandled ufunc/function, an `out=` argument, and
`multiply.reduce` all raise `UnsupportedOperationError` naming the operation;
units are never silently dropped.

## Architecture

| Module | Role |
| --- | --- |
| `src/duq/_arraytypes.py` | Lazy `sys.modules`-based NumPy type detection (never imports NumPy). |
| `src/duq/_numpy/_common.py` | Unit resolution, magnitude conversion, dimensionless/angle stripping, boxing, `compare_core`. |
| `src/duq/_numpy/_ufuncs.py` | The curated `__array_ufunc__` table (ufunc → handler). |
| `src/duq/_numpy/_functions.py` | The curated `__array_function__` table (function → handler). |
| `src/duq/_numpy/_dispatch.py` | Entry points wired into `Quantity` + array introspection/reduction helpers. |
| `src/duq/_quantity.py` | Array magnitude support, protocol hooks, `.shape/.ndim/.size/.dtype/.T`, iteration/indexing, reductions. |
| `src/duq/_unit.py` | `__array_ufunc__ = None`; scales into a `Quantity` for number/array operands. |

## ufunc coverage (`__array_ufunc__`)

**67 distinct ufunc objects** (~75 names; `divide`/`true_divide`, `mod`/`remainder`,
`abs`/`absolute`, `conj`/`conjugate` share one object each).

| Rule | ufuncs |
| --- | --- |
| MULTIPLY (`u1*u2`) | `multiply`, `matmul` |
| DIVIDE (`u1/u2`) | `divide`/`true_divide`, `floor_divide` |
| SAME_DIM (right→left unit) | `add`, `subtract`, `hypot`, `maximum`, `minimum`, `fmax`, `fmin`, `remainder`/`mod`, `fmod`, `nextafter`, `copysign` |
| POWER (uniform scalar exp) | `power`, `float_power` |
| unit powers | `sqrt` (1/2), `cbrt` (1/3), `square` (2), `reciprocal` (-1) |
| PRESERVE | `negative`, `positive`, `absolute`/`abs`, `fabs`, `conj`/`conjugate`, `floor`, `ceil`, `trunc`, `rint` |
| plain (unit-free) | `sign`, `isfinite`, `isnan`, `isinf`, `signbit` |
| DIMENSIONLESS_IN → dimensionless | `exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, `sinh`, `cosh`, `tanh`, `arcsinh`, `arccosh`, `arctanh`, `logaddexp`, `logaddexp2` |
| ANGLE_IN → dimensionless | `sin`, `cos`, `tan` (deg→rad via scale) |
| inverse trig → radian-labelled | `arcsin`, `arccos`, `arctan`, `arctan2` |
| angle conversions | `deg2rad`, `radians`, `rad2deg`, `degrees` |
| comparisons → plain `bool` array | `equal`, `not_equal`, `less`, `less_equal`, `greater`, `greater_equal` |

`method`: `add`/`maximum`/`minimum`.`reduce` & `.accumulate` preserve the unit;
`multiply.reduce` → `UnsupportedOperationError` (ambiguous `unit**n`; suggests a
`.prod()` that v1 deliberately does not provide); every other method → unsupported.
`out=` anywhere → unsupported (Quantity is immutable).

## `__array_function__` coverage

**110 distinct function objects** on NumPy 2.x (a couple more/fewer across versions).

- **Joining/selection:** `concatenate`, `stack`, `hstack`, `vstack`, `dstack`, `column_stack`, `append`, `insert`, `where`, `clip`, `compress`, `take` (→ first-quantity unit; incompatible → `DimensionalityError`).
- **Reductions/stats (PRESERVE):** `sum`, `nansum`, `cumsum`, `nancumsum`, `mean`, `nanmean`, `average` (weighted), `median`, `nanmedian`, `quantile`, `percentile`, `nanquantile`, `nanpercentile`, `min`/`amin`, `max`/`amax`, `nanmin`, `nanmax`, `ptp`, `std`, `nanstd`, `diff`, `ediff1d`. **`var`/`nanvar` → unit^2.** `gradient` → `f_unit/x_unit`, `trapezoid`/`trapz` → `y_unit*x_unit`.
- **Shape/layout (PRESERVE):** `reshape`, `ravel`, `transpose`, `permute_dims`, `swapaxes`, `moveaxis`, `squeeze`, `expand_dims`, `broadcast_to`, `broadcast_arrays`, `flip`, `fliplr`, `flipud`, `roll`, `rot90`, `atleast_1d/2d/3d`, `tile`, `repeat`, `split`, `array_split`, `hsplit`, `vsplit`, `dsplit`, `delete`, `pad` (constant + edge family; else unsupported), `real`, `imag`, `copy`, `around`/`round`, `sort`, `diagonal`, `diag`, `trace`.
- **Linalg-ish (units multiply):** `dot`, `vdot`, `inner`, `outer`, `tensordot`, `cross`, `kron`, `einsum` (`matmul` via the ufunc path); `linalg.norm` PRESERVE. `linalg.solve/inv/det/…` → unsupported in v1.
- **Comparison/search:** `allclose`, `isclose` (unit-aware; `atol` must be a Quantity of the same dimension, or omitted only for dimensionless — else raises), `array_equal`, `array_equiv` (incompatible → `False`), `argmin`/`argmax`/`nanargmin`/`nanargmax`/`argsort`/`count_nonzero`/`nonzero`/`shape`/`ndim`/`size` (plain), `sort`/`unique` (PRESERVE), `searchsorted`, `digitize` (convert), `interp` (x-likes converted, `fp` unit preserved), `meshgrid` (per-input preserved), `histogram` (plain counts, Quantity edges).
- **Creation-like:** `zeros_like`, `empty_like`, `ones_like` (PRESERVE, pint-compatible), `full_like` (fill converted; bare only for dimensionless). `np.asarray(q)`/`np.array(q)` raise via `__array__`.

## Ergonomics & silent-strip guards

- `np.linspace(0,1,5) * u.m`, `u.m * np.arange(3)`, `5 * u.m`, `u.m * 5`, `array / u.m`, `10 / u.s` all → `Quantity`; `1 / u.s` still returns the inverse **Unit**.
- `np.array(q)` / `np.asarray(q)` raise `UnsupportedOperationError` pointing to `duq.ustrip` — the classic silent-strip hole is closed.
- `float(q)`/`int(q)`/`complex(q)`/`bool(q)` coerce **dimensionless** quantities by applying the unit scale — `float(Quantity(50.0, "%")) == 0.5`, `int(Quantity(200.0, "%")) == 2`, `float(Quantity(1.5, "rad")) == 1.5` (angle-labelled units are dimensionless) — and raise with the `ustrip` guidance for anything dimensional (pint-consistent, per lead review). Dimensionless array magnitudes follow NumPy's own coercion/truthiness rules (one element coerces, more raise `ValueError`).
- °C arrays convert correctly; `°C + °C`, `2·°C`, `-°C` raise per the affine policy while `°C − °C` yields kelvin.

## Verification (all green locally)

| Gate | Command | Result |
| --- | --- | --- |
| Lint | `pixi run -e lint lint` | All checks passed |
| Format | `pixi run -e lint fmt-check` | 39 files formatted |
| Types | `pixi run -e type typecheck` | mypy strict, no issues (39 files) |
| Coverage | `pixi run -e test test-cov` | **96.95%** (gate `fail_under=95`), 397 passed |
| NumPy 1.26 | `pixi run -e test-np126 test` | 397 passed (NumPy 1.26.4 / Py 3.11) |
| Py 3.11 | `pixi run -e test-py311 test` | 397 passed |
| Py 3.13 | `pixi run -e test-py313 test` | 397 passed |

No-numpy-import meta test still passes; array docstring Examples verified via `doctest`.

Lead-review confirmations now covered by dedicated tests: `np.isclose`/`np.allclose` on dimensional quantities reject a bare/default `atol` (`DimensionalityError` demanding a Quantity atol; a `mm` atol converts against `m`/`km` operands), `zeros_like`/`ones_like`/`empty_like`/`full_like` preserve units (with `full_like` converting a Quantity fill), and `np.power` works with plain-scalar, 0-d array, NumPy-scalar and 0-d Quantity exponents while non-uniform array exponents raise.

## Spec deviations & judgment calls

1. **`Unit * number` / `number / unit` now yield a Quantity** (spec regression:
   `5 * u.m` and `u.m * 5` → Quantity). This changes two PR 2 core unit tests
   (`unit.__mul__(3)` and `unit.__rtruediv__(2)` previously returned
   `NotImplemented`); both were updated. `1 / unit` still returns the inverse
   Unit, as PR 2 intended. Implemented with `@overload` so `unit * unit` stays a
   `Unit` for the type checker.
2. **Scalar coercions are dimension-aware** (revised per lead review): `float`/
   `int`/`complex`/`bool` convert a *dimensionless* quantity to the bare scale-1
   value and raise only for dimensional quantities. The spec only names
   `float(q)` among the silent-strip guards; the dimensionless carve-out is the
   pint-consistent reading, and `bool` follows the same rule (dimensional
   truthiness would otherwise be affine-unit-dependent).
3. **Dimensionless/angle transcendentals return a dimensionless `Quantity`**
   (unit `"1"`, or `"rad"` for inverse trig) rather than a bare array — matches
   pint and keeps unit tracking composable.
4. **Internal numeric helpers are typed `Any`** (`_mul/_add/_num_*`, and the
   `_numpy` handlers): a single static type cannot span the scalar tower *and*
   ndarray. This is confined to private helpers — every public signature stays
   typed via `numpy.typing`. mypy strict passes with **no new config overrides**;
   the conformance test files carry a localized `# mypy: disable-error-code`
   pragma for the unavoidable "NumPy can't type a duck array" false positives.
5. **`asarray` needs no function-table entry** — `np.asarray(q)` routes through
   `__array__`, which raises; likewise a couple of "skip in v1" items
   (`choose`/`select`) are simply left uncovered and therefore fail loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
