### PR TITLE
feat: JAX integration — jit/grad/vmap-safe unit-carrying arrays (quax)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,5 @@ jobs:
           pixi-version: v0.72.0
           environments: test-jax
           cache: true
-      - name: Run tests with JAX installed
-        run: pixi run -e test-jax test
+      - name: Run tests with JAX installed (duq/jax coverage gate ≥90%)
+        run: pixi run -e test-jax test-jax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **JAX integration — jit/grad/vmap-safe unit-carrying arrays (`duq[jax]`,
+  quax primitive interception):**
+  - New `duq.jax.Quantity`: a `quax.ArrayValue` (equinox pytree) whose
+    magnitude is the traced leaf and whose unit is a **static** field, so the
+    unit is checked and propagated at trace time, participates in `jit`'s
+    cache key (same unit → cached; new unit → retrace), and costs nothing at
+    runtime. Construction from anything `jnp.asarray` accepts, plus
+    `Quantity.from_core(q)`/`q.to_core()` to cross between the NumPy core and
+    JAX; the core `duq.Quantity` now rejects JAX arrays/tracers with a pointer
+    to `duq.jax.Quantity` (without importing JAX).
+  - 93 `lax` primitives registered through the shared `duq._rules` engine —
+    arithmetic with the core affine (`°C`) policy, unit powers
+    (`integer_pow`/`sqrt`/`rsqrt`/`cbrt`/`square`), dimensionless/angle rules
+    (`%` and `deg` rescaled at trace time), converted comparisons
+    (`==`/`!=` on incompatible dimensions → all-False/all-True, matching the
+    NumPy layer), n-ary structure (`concatenate`/`stack`/`select_n`/`sort`/
+    `split`/`pad`/`gather`/`scatter*`), reductions (`reduce_prod` →
+    `unit ** n` via static shapes) and `dot_general` — see
+    `docs/dev/jax_coverage.md` (generated, test-enforced). Control flow
+    (`scan`/`while`/`cond`) keeps units in carries and branches via quax.
+  - Fail-loud everywhere: `materialise()` refuses, and any uncovered
+    primitive raises `UnsupportedOperationError` **naming the primitive**;
+    `np.asarray(q)`/`float(q)`-style coercions follow the core policy
+    (dimensionless converts, dimensional raises with `ustrip` guidance).
+  - `duq.jax.numpy`: a lazily quaxified mirror of `jax.numpy` (including
+    proxied submodules such as `linalg` and curated unit-aware
+    `deg2rad`/`rad2deg` overrides), plus full Python operator support and a
+    unit-aware `.at[...]` indexed-update helper on the quantity itself.
+  - Unit-aware transformation wrappers: `duq.jax.grad`/`jacfwd`/`jacrev`/
+    `hessian` label derivatives with the exact `unit_out / unit_in` unit
+    (Hessians with `unit_out / unit_in²`); `duq.jax.jit`/`vmap` document the
+    pytree pathway (plain `jax.jit`/`jax.vmap` work directly on quantities).
+  - `duq.uconvert`/`duq.ustrip` now dispatch structurally on any
+    quantity flavour via the new `duq.QuantityLike` protocol.
+  - Packaging: the `jax` extra pins `quax>=0.3.6,<0.5` (single-maintainer
+    risk) and `equinox>=0.11`; the pixi `test-jax` environment gets quax from
+    PyPI (not on conda-forge) and CI enforces a dedicated ≥90% coverage gate
+    on `src/duq/jax` (the global 95% gate covers everything else).
+    `import duq` still never imports JAX, and `import duq.jax` without the
+    extra raises a helpful `ImportError` (both asserted by tests).
 - **NumPy integration — unit-carrying arrays (NEP 13 / NEP 18):**
   - The existing `Quantity` now also wraps a NumPy array (or NumPy scalar) as its
     magnitude (`Quantity(np.array(...), unit)`, or `Quantity.from_array([...],

--- a/coverage-jax.toml
+++ b/coverage-jax.toml
@@ -1,0 +1,18 @@
+# Coverage configuration for the test-jax task (pixi run -e test-jax test-jax).
+#
+# The global gate in pyproject.toml omits src/duq/jax (unimportable without
+# the optional jax stack); this config measures exactly that package and
+# enforces its own >=90% gate, per the PR-4 coverage policy.
+
+[tool.coverage.run]
+source = ["duq.jax"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 90
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/docs/dev/generate_jax_coverage.py
+++ b/docs/dev/generate_jax_coverage.py
@@ -1,0 +1,66 @@
+"""Regenerate ``docs/dev/jax_coverage.md`` from ``duq.jax.PRIMITIVE_COVERAGE``.
+
+Run from the repository root inside the test-jax environment::
+
+    pixi run -e test-jax python docs/dev/generate_jax_coverage.py
+
+``tests/jax/test_meta_jax.py`` asserts the generated table stays in sync with
+the registered primitive rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duq.jax
+
+_HEADER = """\
+# duq.jax primitive coverage
+
+Generated from `duq.jax.PRIMITIVE_COVERAGE` (the module-level registry in
+`src/duq/jax/_primitives.py`) by `docs/dev/generate_jax_coverage.py`;
+`tests/jax/test_meta_jax.py` asserts this table stays in sync with the
+registered rules.  Any `lax` primitive **not** listed here fails loud with
+`UnsupportedOperationError` naming the primitive (via
+`duq.jax.Quantity.default`); units are never silently dropped.
+
+The control-flow primitives (`cond`, `while`, `scan`, `pjit`) are handled
+by quax itself and work with quantity carries/branches out of the box.
+"""
+
+_FOOTER = """\
+## Known exclusions
+
+- `jax.numpy.interp` compares its inputs against a hard-coded epsilon
+  literal internally (dimensionally unsound at the primitive level); strip
+  units with `duq.ustrip` around it.
+- `jnp.deg2rad`/`rad2deg`/`radians`/`degrees` lower to a bare
+  multiplication, so `duq.jax.numpy` ships curated unit-aware overrides
+  for them instead of the quaxified originals.
+- `lax.linalg` decompositions (`cholesky`, `svd`, `eig`, ...),
+  `cumlogsumexp`, `scatter_mul`, FFTs and convolutions are uncovered and
+  fail loud; convert to a canonical unit and strip before calling them.
+- `cumprod`/`reduce_prod` differ: `reduce_prod` maps to `unit ** n`
+  (static reduced size), while `cumprod` would give every element a
+  different unit and is rejected for dimensional operands.
+"""
+
+
+def main() -> None:
+    """Write the coverage table next to this script."""
+    rows = duq.jax.PRIMITIVE_COVERAGE
+    name_width = max(len(name) for name, _ in rows) + 2
+    desc_width = max(len(desc) for _, desc in rows)
+    lines = [_HEADER]
+    lines.append(f"| {'Primitive'.ljust(name_width)} | Unit rule |")
+    lines.append(f"|{'-' * (name_width + 2)}|{'-' * (desc_width + 2)}|")
+    lines.extend(f"| {('`' + name + '`').ljust(name_width)} | {desc} |" for name, desc in rows)
+    lines.append("")
+    lines.append(_FOOTER)
+    target = Path(__file__).with_name("jax_coverage.md")
+    target.write_text("\n".join(lines))
+    print(f"wrote {target} ({len(rows)} primitives)")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/jax_coverage.md
+++ b/docs/dev/jax_coverage.md
@@ -1,0 +1,122 @@
+# duq.jax primitive coverage
+
+Generated from `duq.jax.PRIMITIVE_COVERAGE` (the module-level registry in
+`src/duq/jax/_primitives.py`) by `docs/dev/generate_jax_coverage.py`;
+`tests/jax/test_meta_jax.py` asserts this table stays in sync with the
+registered rules.  Any `lax` primitive **not** listed here fails loud with
+`UnsupportedOperationError` naming the primitive (via
+`duq.jax.Quantity.default`); units are never silently dropped.
+
+The control-flow primitives (`cond`, `while`, `scan`, `pjit`) are handled
+by quax itself and work with quantity carries/branches out of the box.
+
+| Primitive              | Unit rule |
+|------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `abs`                  | unit preserved (affine rejected) |
+| `acos`                 | dimensionless in, radian out |
+| `acosh`                | dimensionless in (scale applied), dimensionless out |
+| `add`                  | same dimension; right operand converted to the left unit |
+| `argmax`               | plain index array out |
+| `argmin`               | plain index array out |
+| `asin`                 | dimensionless in, radian out |
+| `asinh`                | dimensionless in (scale applied), dimensionless out |
+| `atan`                 | dimensionless in, radian out |
+| `atan2`                | same dimension in, radian out |
+| `atanh`                | dimensionless in (scale applied), dimensionless out |
+| `bitcast_convert_type` | plain array out (raw bits carry no unit) |
+| `broadcast_in_dim`     | structural; unit preserved |
+| `cbrt`                 | unit ** 1/3 |
+| `ceil`                 | unit preserved |
+| `concatenate`          | all operands converted to the first quantity's unit |
+| `conj`                 | unit preserved |
+| `convert_element_type` | structural; unit preserved |
+| `copy`                 | structural; unit preserved |
+| `cos`                  | angle in (rad/deg scale-converted at trace time), dimensionless out |
+| `cosh`                 | dimensionless in (scale applied), dimensionless out |
+| `cummax`               | cumulative; unit preserved |
+| `cummin`               | cumulative; unit preserved |
+| `cumprod`              | scale-1 dimensionless only (per-element unit is ambiguous) |
+| `cumsum`               | cumulative; unit preserved |
+| `div`                  | units divide |
+| `dot_general`          | units multiply (matmul/dot/einsum contractions) |
+| `dynamic_slice`        | indexing; unit preserved |
+| `dynamic_update_slice` | quantity update converted to the operand's unit; plain update adopts it |
+| `eq`                   | converted compare; incompatible dims -> all-False |
+| `eq_to`                | total-order compare (converted) |
+| `erf`                  | dimensionless in (scale applied), dimensionless out |
+| `erf_inv`              | dimensionless in (scale applied), dimensionless out |
+| `erfc`                 | dimensionless in (scale applied), dimensionless out |
+| `exp`                  | dimensionless in (scale applied), dimensionless out |
+| `exp2`                 | dimensionless in (scale applied), dimensionless out |
+| `expm1`                | dimensionless in (scale applied), dimensionless out |
+| `floor`                | unit preserved |
+| `gather`               | indexing; unit preserved |
+| `ge`                   | converted compare; incompatible dims raise |
+| `gt`                   | converted compare; incompatible dims raise |
+| `imag`                 | unit preserved |
+| `integer_pow`          | unit ** y (static integer exponent) |
+| `is_finite`            | plain bool array out |
+| `le`                   | converted compare; incompatible dims raise |
+| `le_to`                | total-order compare (converted) |
+| `log`                  | dimensionless in (scale applied), dimensionless out |
+| `log1p`                | dimensionless in (scale applied), dimensionless out |
+| `logistic`             | dimensionless in (scale applied), dimensionless out |
+| `lt`                   | converted compare; incompatible dims raise |
+| `lt_to`                | total-order compare (converted) |
+| `max`                  | same dimension; unit preserved |
+| `min`                  | same dimension; unit preserved |
+| `mul`                  | units multiply |
+| `ne`                   | converted compare; incompatible dims -> all-True |
+| `neg`                  | unit preserved (affine rejected) |
+| `nextafter`            | same dimension; unit preserved |
+| `pad`                  | quantity padding value converted to the operand's unit; plain adopts it |
+| `pow`                  | unit ** concrete dimensionless exponent (traced exponent rejected) |
+| `real`                 | unit preserved |
+| `reduce_and`           | plain bool array out |
+| `reduce_max`           | reduction; unit preserved |
+| `reduce_min`           | reduction; unit preserved |
+| `reduce_or`            | plain bool array out |
+| `reduce_prod`          | unit ** reduced_size (shapes are static) |
+| `reduce_sum`           | reduction; unit preserved |
+| `rem`                  | same dimension; unit preserved |
+| `reshape`              | structural; unit preserved |
+| `rev`                  | structural; unit preserved |
+| `round`                | unit preserved |
+| `rsqrt`                | unit ** -1/2 |
+| `scatter`              | quantity updates converted to the operand's unit; plain updates adopt it |
+| `scatter-add`          | quantity updates converted to the operand's unit; plain updates adopt it |
+| `scatter-max`          | quantity updates converted to the operand's unit; plain updates adopt it |
+| `scatter-min`          | quantity updates converted to the operand's unit; plain updates adopt it |
+| `scatter-sub`          | quantity updates converted to the operand's unit; plain updates adopt it |
+| `select_n`             | quantity branches converted to the last quantity case's unit (np.where parity); plain branches adopt it; predicate plain |
+| `sign`                 | plain array out (sign is scale-free) |
+| `sin`                  | angle in (rad/deg scale-converted at trace time), dimensionless out |
+| `sinh`                 | dimensionless in (scale applied), dimensionless out |
+| `slice`                | structural; unit preserved |
+| `sort`                 | per-operand; each output keeps its operand's unit |
+| `split`                | structural; unit preserved on every output |
+| `sqrt`                 | unit ** 1/2 |
+| `square`               | unit squared |
+| `squeeze`              | structural; unit preserved |
+| `stack`                | all operands converted to the first quantity's unit |
+| `stop_gradient`        | structural; unit preserved |
+| `sub`                  | same dimension; degC - degC yields the coherent SI difference (K) |
+| `tan`                  | angle in (rad/deg scale-converted at trace time), dimensionless out |
+| `tanh`                 | dimensionless in (scale applied), dimensionless out |
+| `tile`                 | structural; unit preserved |
+| `transpose`            | structural; unit preserved |
+
+## Known exclusions
+
+- `jax.numpy.interp` compares its inputs against a hard-coded epsilon
+  literal internally (dimensionally unsound at the primitive level); strip
+  units with `duq.ustrip` around it.
+- `jnp.deg2rad`/`rad2deg`/`radians`/`degrees` lower to a bare
+  multiplication, so `duq.jax.numpy` ships curated unit-aware overrides
+  for them instead of the quaxified originals.
+- `lax.linalg` decompositions (`cholesky`, `svd`, `eig`, ...),
+  `cumlogsumexp`, `scatter_mul`, FFTs and convolutions are uncovered and
+  fail loud; convert to a canonical unit and strip before calling them.
+- `cumprod`/`reduce_prod` differ: `reduce_prod` maps to `unit ** n`
+  (static reduced size), while `cumprod` would give every element a
+  different unit and is rejected for dimensional operands.

--- a/pixi.lock
+++ b/pixi.lock
@@ -552,10 +552,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -567,16 +569,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -588,6 +599,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
@@ -627,14 +639,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.18.0-py313h9cbb6b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/18/19e01dbbaececb75815abb37bc71e10d87a7561829b4eae47ec3b342c94f/plum_dispatch-2.9.0-cp313-cp313-macosx_10_13_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -646,6 +666,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
@@ -683,6 +704,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - pypi: ./
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
   test-np126:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -3059,6 +3086,21 @@ packages:
   run_exports: {}
   size: 303705
   timestamp: 1781320269259
+- conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
+  sha256: 6bb6647fe1685ae9c199d0836b881ab91e7ea9ba122a8c1fdfbe3cbfe23d7ff5
+  md5: f4af25e0754db77859e11977c988b6ef
+  depends:
+  - jax >=0.4.38,!=0.7.0,!=0.7.1
+  - jaxtyping >=0.2.20
+  - python >=3.10
+  - typing_extensions >=4.5.0
+  - wadler-lindig >=0.1.0
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/equinox?source=compressed-mapping
+  run_exports: {}
+  size: 140684
+  timestamp: 1783509191244
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -3154,6 +3196,19 @@ packages:
   run_exports: {}
   size: 2129277
   timestamp: 1781775700801
+- conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
+  sha256: e0c861f192c9640ffdc74c6c813012d1cce48038e456a16fcf464b99b77feae1
+  md5: d2fa6995ffc3e55ea22e70c6582489ab
+  depends:
+  - python >=3.11
+  - wadler-lindig >=0.1.3
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jaxtyping?source=hash-mapping
+  run_exports: {}
+  size: 49623
+  timestamp: 1782331952975
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -3454,6 +3509,19 @@ packages:
   run_exports: {}
   size: 3272894
   timestamp: 1783424056921
+- conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
+  sha256: af400decd8578d521c752594bb9380eb4d1e1e53e919c18dd2d65429f032e36c
+  md5: d93a6a7cf86ac0c6c2f00c287c3a030c
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/wadler-lindig?source=hash-mapping
+  run_exports: {}
+  size: 28051
+  timestamp: 1752728420929
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
   sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
   md5: ba3dcdc8584155c97c648ae9c044b7a3
@@ -6323,4 +6391,201 @@ packages:
   requires_dist:
   - numpy>=1.26
   - jax>=0.5 ; extra == 'jax'
+  - quax>=0.3.6,<0.5 ; extra == 'jax'
+  - equinox>=0.11 ; extra == 'jax'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+  name: quax
+  version: 0.3.6
+  sha256: dbe08ddca8d6df4383feffa5943f7bceaa4d273fd588901d2a5819e36ffce815
+  requires_dist:
+  - equinox>=0.13.2
+  - jax>=0.5.3,!=0.7.0,!=0.7.1
+  - jaxtyping>=0.3.3
+  - packaging>=20.0
+  - plum-dispatch>=2.5.7 ; python_full_version < '3.14'
+  - plum-dispatch>=2.9.0 ; python_full_version >= '3.14'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl
+  name: plum-dispatch
+  version: 2.9.0
+  sha256: 5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397
+  requires_dist:
+  - beartype>=0.16.2 ; python_full_version < '3.14'
+  - beartype>=0.22.2 ; python_full_version >= '3.14'
+  - rich>=10.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+  name: beartype
+  version: 0.22.9
+  sha256: d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2
+  requires_dist:
+  - autoapi>=0.9.0 ; extra == 'dev'
+  - celery ; extra == 'dev'
+  - click ; extra == 'dev'
+  - coverage>=5.5 ; extra == 'dev'
+  - docutils>=0.22.0 ; extra == 'dev'
+  - equinox ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'dev'
+  - fastmcp ; python_full_version < '3.14' and extra == 'dev'
+  - jax[cpu] ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'dev'
+  - jaxtyping ; sys_platform == 'linux' and extra == 'dev'
+  - langchain ; python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'dev'
+  - mypy>=0.800 ; platform_python_implementation != 'PyPy' and extra == 'dev'
+  - nuitka>=1.2.6 ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'dev'
+  - numba ; python_full_version < '3.14' and extra == 'dev'
+  - numpy ; python_full_version < '3.15' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'dev'
+  - pandera>=0.26.0 ; python_full_version < '3.14' and extra == 'dev'
+  - poetry ; extra == 'dev'
+  - polars ; python_full_version < '3.14' and extra == 'dev'
+  - pydata-sphinx-theme<=0.7.2 ; extra == 'dev'
+  - pygments ; extra == 'dev'
+  - pyinstaller ; extra == 'dev'
+  - pyright>=1.1.370 ; extra == 'dev'
+  - pytest>=6.2.0 ; extra == 'dev'
+  - redis ; extra == 'dev'
+  - rich-click ; extra == 'dev'
+  - setuptools ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - sphinx>=4.2.0,<6.0.0 ; extra == 'dev'
+  - sphinxext-opengraph>=0.7.5 ; extra == 'dev'
+  - sqlalchemy ; extra == 'dev'
+  - torch ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'dev'
+  - tox>=3.20.1 ; extra == 'dev'
+  - typer ; extra == 'dev'
+  - typing-extensions>=3.10.0.0 ; extra == 'dev'
+  - xarray ; python_full_version < '3.15' and extra == 'dev'
+  - mkdocs-material[imaging]>=9.6.0 ; extra == 'doc-ghp'
+  - mkdocstrings-python-xref>=1.16.0 ; extra == 'doc-ghp'
+  - mkdocstrings-python>=1.16.0 ; extra == 'doc-ghp'
+  - autoapi>=0.9.0 ; extra == 'doc-rtd'
+  - pydata-sphinx-theme<=0.7.2 ; extra == 'doc-rtd'
+  - setuptools ; extra == 'doc-rtd'
+  - sphinx>=4.2.0,<6.0.0 ; extra == 'doc-rtd'
+  - sphinxext-opengraph>=0.7.5 ; extra == 'doc-rtd'
+  - celery ; extra == 'test'
+  - click ; extra == 'test'
+  - coverage>=5.5 ; extra == 'test'
+  - docutils>=0.22.0 ; extra == 'test'
+  - equinox ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'test'
+  - fastmcp ; python_full_version < '3.14' and extra == 'test'
+  - jax[cpu] ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'test'
+  - jaxtyping ; sys_platform == 'linux' and extra == 'test'
+  - langchain ; python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'test'
+  - mypy>=0.800 ; platform_python_implementation != 'PyPy' and extra == 'test'
+  - nuitka>=1.2.6 ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'test'
+  - numba ; python_full_version < '3.14' and extra == 'test'
+  - numpy ; python_full_version < '3.15' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'test'
+  - pandera>=0.26.0 ; python_full_version < '3.14' and extra == 'test'
+  - poetry ; extra == 'test'
+  - polars ; python_full_version < '3.14' and extra == 'test'
+  - pygments ; extra == 'test'
+  - pyinstaller ; extra == 'test'
+  - pyright>=1.1.370 ; extra == 'test'
+  - pytest>=6.2.0 ; extra == 'test'
+  - redis ; extra == 'test'
+  - rich-click ; extra == 'test'
+  - sphinx ; extra == 'test'
+  - sqlalchemy ; extra == 'test'
+  - torch ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'test'
+  - tox>=3.20.1 ; extra == 'test'
+  - typer ; extra == 'test'
+  - typing-extensions>=3.10.0.0 ; extra == 'test'
+  - xarray ; python_full_version < '3.15' and extra == 'test'
+  - celery ; extra == 'test-tox'
+  - click ; extra == 'test-tox'
+  - docutils>=0.22.0 ; extra == 'test-tox'
+  - equinox ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'test-tox'
+  - fastmcp ; python_full_version < '3.14' and extra == 'test-tox'
+  - jax[cpu] ; python_full_version < '3.15' and sys_platform == 'linux' and extra == 'test-tox'
+  - jaxtyping ; sys_platform == 'linux' and extra == 'test-tox'
+  - langchain ; python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'test-tox'
+  - mypy>=0.800 ; platform_python_implementation != 'PyPy' and extra == 'test-tox'
+  - nuitka>=1.2.6 ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'test-tox'
+  - numba ; python_full_version < '3.14' and extra == 'test-tox'
+  - numpy ; python_full_version < '3.15' and platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and extra == 'test-tox'
+  - pandera>=0.26.0 ; python_full_version < '3.14' and extra == 'test-tox'
+  - poetry ; extra == 'test-tox'
+  - polars ; python_full_version < '3.14' and extra == 'test-tox'
+  - pygments ; extra == 'test-tox'
+  - pyinstaller ; extra == 'test-tox'
+  - pyright>=1.1.370 ; extra == 'test-tox'
+  - pytest>=6.2.0 ; extra == 'test-tox'
+  - redis ; extra == 'test-tox'
+  - rich-click ; extra == 'test-tox'
+  - sphinx ; extra == 'test-tox'
+  - sqlalchemy ; extra == 'test-tox'
+  - torch ; python_full_version < '3.14' and sys_platform == 'linux' and extra == 'test-tox'
+  - typer ; extra == 'test-tox'
+  - typing-extensions>=3.10.0.0 ; extra == 'test-tox'
+  - xarray ; python_full_version < '3.15' and extra == 'test-tox'
+  - coverage>=5.5 ; extra == 'test-tox-coverage'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+  name: rich
+  version: 15.0.0
+  sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+  requires_dist:
+  - ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+  - markdown-it-py>=2.2.0
+  - pygments>=2.13.0,<3.0.0
+  requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+  name: mdurl
+  version: 0.1.2
+  sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+  name: markdown-it-py
+  version: 4.2.0
+  sha256: 9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+  requires_dist:
+  - mdurl~=0.1
+  - psutil ; extra == 'benchmarking'
+  - pytest ; extra == 'benchmarking'
+  - pytest-benchmark ; extra == 'benchmarking'
+  - commonmark~=0.9 ; extra == 'compare'
+  - markdown~=3.4 ; extra == 'compare'
+  - mistletoe~=1.0 ; extra == 'compare'
+  - mistune~=3.0 ; extra == 'compare'
+  - panflute~=2.3 ; extra == 'compare'
+  - markdown-it-pyrs ; extra == 'compare'
+  - linkify-it-py>=1,<3 ; extra == 'linkify'
+  - mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+  - gprof2dot ; extra == 'profiling'
+  - mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+  - myst-parser ; extra == 'rtd'
+  - pyyaml ; extra == 'rtd'
+  - sphinx ; extra == 'rtd'
+  - sphinx-copybutton ; extra == 'rtd'
+  - sphinx-design ; extra == 'rtd'
+  - sphinx-book-theme~=1.0 ; extra == 'rtd'
+  - jupyter-sphinx ; extra == 'rtd'
+  - ipykernel ; extra == 'rtd'
+  - coverage ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - pytest-timeout ; extra == 'testing'
+  - requests ; extra == 'testing'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cb/18/19e01dbbaececb75815abb37bc71e10d87a7561829b4eae47ec3b342c94f/plum_dispatch-2.9.0-cp313-cp313-macosx_10_13_x86_64.whl
+  name: plum-dispatch
+  version: 2.9.0
+  sha256: 78987caf558fbdd675a7a4a5c144069f1f9524610195123fb7d0f0234d0af01a
+  requires_dist:
+  - beartype>=0.16.2 ; python_full_version < '3.14'
+  - beartype>=0.22.2 ; python_full_version >= '3.14'
+  - rich>=10.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: plum-dispatch
+  version: 2.9.0
+  sha256: 36662d76ae6d87aaa041fade036d2242f0b88b68c9fb4c96b7ba0026320065d3
+  requires_dist:
+  - beartype>=0.16.2 ; python_full_version < '3.14'
+  - beartype>=0.22.2 ; python_full_version >= '3.14'
+  - rich>=10.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.10'

--- a/pixi.lock
+++ b/pixi.lock
@@ -1632,13 +1632,19 @@ environments:
   type:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ast-serialize-0.6.0-py310hd8a072f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-25.9.23-hb7d4c21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hypothesis-6.156.3-py311h902ca64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.10.2-cpu_py311hceffaa2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
@@ -1648,23 +1654,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h538a264_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py311h912ec1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-2.2.0-py311hb6eeb03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py311h2e04523_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-threadpool_h77e0eb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-cpu-threadpool-3.12-threadpool_hc2f90bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.13.0-py311haee01d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
@@ -1672,9 +1686,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1686,15 +1705,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/01/eee83f936500e3e0100ac421483fa78768fec70214e4ce0241187ec3a2f1/plum_dispatch-2.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1706,11 +1738,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ast-serialize-0.6.0-py310hb9b2626_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/flatbuffers-25.9.23-h6982a40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hypothesis-6.156.3-py311h3a14e8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jaxlib-0.10.2-cpu_py311h3ac22a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260107.1-cxx17_h7ed6875_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-8_he492b99_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-8_h9b27e0a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda
@@ -1719,30 +1757,48 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.78.1-h147dede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-8_h859234e_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-openmp_h9e49c7b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hb0ea838_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.3-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ml_dtypes-0.5.4-np2py311hca72124_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-2.2.0-py311h9f7f2fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py311h2c4eb96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/onednn-3.12-omp_h71bb16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py311ha332486_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.15-ha9537fe_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-librt-0.13.0-py311h15eb09d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2025.11.05-h77e0585_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.17.1-py311h556693a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/20/7aa36a01b1689d427a9fc20c80b1c0bc8340d1413c8071f08fb1e9a01939/plum_dispatch-2.9.0-cp311-cp311-macosx_10_9_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/equinox-0.13.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jax-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaxtyping-0.3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opt_einsum-3.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1754,10 +1810,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wadler-lindig-0.1.7-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ast-serialize-0.6.0-py310h3b8a9b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/flatbuffers-25.9.23-h9e8ef45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hypothesis-6.156.3-py311hf7c400d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jaxlib-0.10.2-cpu_py311h001ef46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
@@ -1766,12 +1828,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-hb82ec63_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ml_dtypes-0.5.4-np2py311hb7ce6e1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-2.2.0-py311h5277e72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.6-py311hbd1492f_0.conda
@@ -1779,59 +1845,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py311he363849_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h0c9c016_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-librt-0.13.0-py311he363849_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py311h9a58382_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.15-hd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ast-serialize-0.6.0-py310ha413424_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hypothesis-6.156.3-py311hf51aa87_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-8_h2a3cdd5_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-8_hf9ab0e9_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.3-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.3-h692994f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.3-hbc0d294_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.8-h4fa8253_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-2.2.0-py311h4ea48c9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py311h65cb7f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py311hf893f09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.15-h0159041_1_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-librt-0.13.0-py311hf893f09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+      - pypi: https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1864,6 +1887,8 @@ packages:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ast-serialize?source=hash-mapping
   run_exports: {}
   size: 1120486
   timestamp: 1782863830347
@@ -2045,6 +2070,37 @@ packages:
   run_exports: {}
   size: 1542171
   timestamp: 1783528849204
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.10.2-cpu_py311hceffaa2_0.conda
+  sha256: 0b51bff46ff6b3e4fb02c8384f1abd761cc6d74a52df18af70521d1797d6778b
+  md5: d3671ba830c9b5084794071632cb95f5
+  depends:
+  - python
+  - scipy >=1.9
+  - ml_dtypes >=0.2.0
+  - onednn-cpu-threadpool
+  - libgcc >=15
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - numpy >=1.23,<3
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - openssl >=3.5.7,<4.0a0
+  - onednn >=3.12,<4.0a0
+  - flatbuffers >=25.9.23,<25.9.24.0a0
+  - python_abi 3.11.* *_cp311
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libre2-11 >=2025.11.5
+  - re2
+  constrains:
+  - jax >=0.10.2
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/jaxlib?source=hash-mapping
+  run_exports: {}
+  size: 67553833
+  timestamp: 1783084338605
 - conda: https://conda.anaconda.org/conda-forge/linux-64/jaxlib-0.10.2-cpu_py313hea21797_0.conda
   sha256: 1d624708f47ced695b232e3be283a7e44f43ebdac1ba8fd51a2c94db1a5236cd
   md5: 2211316e07128eb2cda6308a01ca086f
@@ -2465,6 +2521,22 @@ packages:
     - libzlib >=1.3.2,<2.0a0
   size: 63629
   timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py311h912ec1f_1.conda
+  sha256: 0b9b24d1d6da203729d75c74c531a632e965d0a5a973da964b666637948f5a0b
+  md5: 81be6dcbed9f37c8afb78c2e24de3fe4
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
+  license: MPL-2.0 AND Apache-2.0
+  purls:
+  - pkg:pypi/ml-dtypes?source=hash-mapping
+  run_exports: {}
+  size: 345364
+  timestamp: 1771362487210
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.5.4-np2py313h73dcb5b_1.conda
   sha256: c19f433c80041ebb149d7519a99f70f676303905aa3d5ac133d5ca2ddb0c9ad1
   md5: ebfa673f78cd048d1ff357050a353aa0
@@ -2496,6 +2568,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
   run_exports: {}
   size: 22011905
   timestamp: 1783529086762
@@ -2684,6 +2758,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   run_exports: {}
   size: 231786
   timestamp: 1769678156460
@@ -2826,6 +2902,8 @@ packages:
   - libgcc >=14
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/librt?source=compressed-mapping
   run_exports: {}
   size: 162979
   timestamp: 1783529464789
@@ -2886,6 +2964,30 @@ packages:
   run_exports: {}
   size: 9356259
   timestamp: 1783653725254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_1.conda
+  sha256: 3ae2ff1d1cc5930de2ca6ac03216118bdf13b2af6098e28e827f1ba25bfcbc4e
+  md5: 089de2ee37e4e19885c985a4fe4aaf14
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=hash-mapping
+  run_exports: {}
+  size: 17303931
+  timestamp: 1779874783665
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
   sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
   md5: a32f88181ff9a3451c71be1f17a7c799
@@ -2977,6 +3079,7 @@ packages:
   - python-gil
   license: MIT
   license_family: MIT
+  purls: []
   run_exports: {}
   size: 8191
   timestamp: 1744137672556
@@ -3072,6 +3175,7 @@ packages:
   - python >=3.11,<3.12.0a0
   - python_abi * *_cp311
   license: Python-2.0
+  purls: []
   run_exports: {}
   size: 48482
   timestamp: 1781148385557
@@ -3216,6 +3320,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mypy-extensions?source=hash-mapping
   run_exports: {}
   size: 11766
   timestamp: 1745776666688
@@ -3262,6 +3368,8 @@ packages:
   - python >=3.10
   license: MPL-2.0
   license_family: MOZILLA
+  purls:
+  - pkg:pypi/pathspec?source=hash-mapping
   run_exports: {}
   size: 56559
   timestamp: 1777271601895
@@ -3384,6 +3492,7 @@ packages:
   - cpython 3.11.15.*
   - python_abi * *_cp311
   license: Python-2.0
+  purls: []
   run_exports: {}
   size: 48417
   timestamp: 1781148405955
@@ -3562,6 +3671,8 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ast-serialize?source=hash-mapping
   run_exports: {}
   size: 1111573
   timestamp: 1782863893027
@@ -3745,6 +3856,36 @@ packages:
     - icu >=78.3,<79.0a0
   size: 12273764
   timestamp: 1773822733780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/jaxlib-0.10.2-cpu_py311h3ac22a7_0.conda
+  sha256: 01a6a7b16002e1c56603ca911a50c4225b967404d832834e2397e95eecfacbbb
+  md5: 9dc0cb4875716623a103b76cdb899f53
+  depends:
+  - python
+  - scipy >=1.9
+  - ml_dtypes >=0.2.0
+  - python 3.11.* *_cpython
+  - __osx >=11.0
+  - libcxx >=20
+  - libgrpc >=1.78.1,<1.79.0a0
+  - onednn >=3.12,<4.0a0
+  - flatbuffers >=25.9.23,<25.9.24.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - python_abi 3.11.* *_cp311
+  - libre2-11 >=2025.11.5
+  - re2
+  - openssl >=3.5.7,<4.0a0
+  - numpy >=1.23,<3
+  constrains:
+  - jax >=0.10.2
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/jaxlib?source=hash-mapping
+  run_exports: {}
+  size: 83245247
+  timestamp: 1783086908290
 - conda: https://conda.anaconda.org/conda-forge/osx-64/jaxlib-0.10.2-cpu_py313h8119ac7_0.conda
   sha256: 2edcf181a9f3d060cee2d3e6055f810ae10d696f70139de7eda7cb15096001df
   md5: f914cf3cf5ec654b27ddad89071909e8
@@ -4074,6 +4215,21 @@ packages:
     - llvm-openmp >=22.1.8
   size: 311645
   timestamp: 1781737360942
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ml_dtypes-0.5.4-np2py311hca72124_1.conda
+  sha256: 973709b3c3c4ed16e46b4bc56677d7cdbe4a1a2423d98c0bb59288d69cf363c2
+  md5: f9cc89191baff5ab7b802a35300177d5
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=10.13
+  - python_abi 3.11.* *_cp311
+  - numpy >=1.23,<3
+  license: MPL-2.0 AND Apache-2.0
+  purls:
+  - pkg:pypi/ml-dtypes?source=hash-mapping
+  run_exports: {}
+  size: 278952
+  timestamp: 1771362390400
 - conda: https://conda.anaconda.org/conda-forge/osx-64/ml_dtypes-0.5.4-np2py313h1160f3e_1.conda
   sha256: 07233550aa71f5564f6d24729d276b54d97a4d1536f1e9ca28aea622816b2258
   md5: 2fc47fe155516c71a76bbe21d23081ec
@@ -4103,6 +4259,8 @@ packages:
   - __osx >=11.0
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
   run_exports: {}
   size: 14799148
   timestamp: 1783529174958
@@ -4265,6 +4423,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   run_exports: {}
   size: 242642
   timestamp: 1769678292465
@@ -4390,6 +4550,8 @@ packages:
   - __osx >=11.0
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/librt?source=hash-mapping
   run_exports: {}
   size: 133211
   timestamp: 1783529555045
@@ -4447,6 +4609,29 @@ packages:
   run_exports: {}
   size: 9348629
   timestamp: 1783653896015
+- conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.17.1-py311h556693a_1.conda
+  sha256: 4e68affca9e1d14cdb1fe6910c459ec4bd01b1217a867f7cfbf40830951f80aa
+  md5: 972007d34efaf5755603391a91e7d50f
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=hash-mapping
+  run_exports: {}
+  size: 15513987
+  timestamp: 1779875850168
 - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.18.0-py313h9cbb6b6_0.conda
   sha256: 0338d5d5ba0820f86983aeeaad996471bd8f52f3f6ef6ca0a1cbb0cd47215837
   md5: 36f6aac8710abd70e13c02e24509506e
@@ -4551,6 +4736,8 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ast-serialize?source=hash-mapping
   run_exports: {}
   size: 1077921
   timestamp: 1782863843092
@@ -4729,6 +4916,34 @@ packages:
   run_exports: {}
   size: 1242527
   timestamp: 1783528914899
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jaxlib-0.10.2-cpu_py311h001ef46_0.conda
+  sha256: c40fd682da7e5e494b01774975e26be97a6a9f46cbeff6571ec2efbc0695075d
+  md5: d1f429979297cf8d5b3a528e35278c92
+  depends:
+  - python
+  - scipy >=1.9
+  - ml_dtypes >=0.2.0
+  - libcxx >=20
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libabseil * cxx17*
+  - libgrpc >=1.78.1,<1.79.0a0
+  - python_abi 3.11.* *_cp311
+  - flatbuffers >=25.9.23,<25.9.24.0a0
+  - openssl >=3.5.7,<4.0a0
+  - numpy >=1.23,<3
+  - libre2-11 >=2025.11.5
+  - re2
+  constrains:
+  - jax >=0.10.2
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/jaxlib?source=hash-mapping
+  run_exports: {}
+  size: 77278270
+  timestamp: 1783086781212
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jaxlib-0.10.2-cpu_py313hd8c01bf_0.conda
   sha256: fe02c3525d21520b589bc45d60cb714e0107264f75ad2be87994db8dc7621f9f
   md5: 8dbe3487646a1deb19f89386964d40b4
@@ -5055,6 +5270,22 @@ packages:
     - llvm-openmp >=22.1.8
   size: 286313
   timestamp: 1781736516782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ml_dtypes-0.5.4-np2py311hb7ce6e1_1.conda
+  sha256: d71365cdb660fe80cde6572482de85eaa499faa0ddb08d5e7bd5d8c384c88382
+  md5: fa76b2aaefadfc2e4908689a351f158a
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.11.* *_cpython
+  - libcxx >=19
+  - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
+  license: MPL-2.0 AND Apache-2.0
+  purls:
+  - pkg:pypi/ml-dtypes?source=hash-mapping
+  run_exports: {}
+  size: 242654
+  timestamp: 1771362416807
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ml_dtypes-0.5.4-np2py313hdc65ad0_1.conda
   sha256: 1eb9af1c15166fb708edaaed7bcd6148eeb2a09c11309a35cf32d0e30ddfb877
   md5: 6a036407f25040aeb07142b247b7d25b
@@ -5085,6 +5316,8 @@ packages:
   - __osx >=11.0
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/mypy?source=hash-mapping
   run_exports: {}
   size: 13505032
   timestamp: 1783529142852
@@ -5234,6 +5467,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
   run_exports: {}
   size: 245203
   timestamp: 1769678306347
@@ -5360,6 +5595,8 @@ packages:
   - __osx >=11.0
   - python_abi 3.11.* *_cp311
   license: MIT
+  purls:
+  - pkg:pypi/librt?source=hash-mapping
   run_exports: {}
   size: 133537
   timestamp: 1783529588477
@@ -5418,6 +5655,29 @@ packages:
   run_exports: {}
   size: 8557660
   timestamp: 1783653958411
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py311h9a58382_1.conda
+  sha256: b45f87414da242a9e40eb934e89513a856e6236d681611c2c9a21d074b03ef5a
+  md5: 15f96f91b13cbefddbf998368d06adef
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=hash-mapping
+  run_exports: {}
+  size: 13954661
+  timestamp: 1779874558902
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
   sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
   md5: 110ff05ffef908af95192bb17c4006a0
@@ -5496,22 +5756,6 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 433413
   timestamp: 1764777166076
-- conda: https://conda.anaconda.org/conda-forge/win-64/ast-serialize-0.6.0-py310ha413424_0.conda
-  noarch: python
-  sha256: b01a994de3afb922ec5dc07627cb2daa09b4c4b6983644016f3f8bd7abebfc9f
-  md5: 76c848548ac90971be931212647a2639
-  depends:
-  - python >=3.10
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 1075388
-  timestamp: 1782863865593
 - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
   sha256: 76dfb71df5e8d1c4eded2dbb5ba15bb8fb2e2b0fe42d94145d5eed4c75c35902
   md5: 4cb8e6b48f67de0b018719cdf1136306
@@ -5928,25 +6172,6 @@ packages:
   run_exports: {}
   size: 114354729
   timestamp: 1779293121860
-- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-2.2.0-py311h4ea48c9_0.conda
-  sha256: d7fab513310e13cb0d3fd23b92c5b6e5e514bfcb03930e1aca7da06c7cee4438
-  md5: f4305d64faae96d4bb91a095417cb5c5
-  depends:
-  - ast-serialize >=0.6.0,<1.0.0
-  - mypy_extensions >=1.0.0
-  - pathspec >=1.0.0
-  - python
-  - python-librt >=0.12.0
-  - typing_extensions >=4.6.0
-  - psutil >=4.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  run_exports: {}
-  size: 10675706
-  timestamp: 1783529686555
 - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
   sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
   md5: 7b240edd44fd7a0991aa409b07cee776
@@ -6087,20 +6312,6 @@ packages:
     - openssl >=3.6.3,<4.0a0
   size: 9414790
   timestamp: 1781071745579
-- conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py311hf893f09_0.conda
-  sha256: 32da17824abadd1f5b46faedfa4964c7b1817b11887c2e8bb4e48628da51b93a
-  md5: fd968cdacc7967efd0ff5ef1805b812c
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 249478
-  timestamp: 1769678166841
 - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.15-h0159041_1_cpython.conda
   build_number: 1
   sha256: 32716d8df907696e856cbd4cdcc5fe89ddae01c7c9a8cc99bd42260bf6d9a4a2
@@ -6215,19 +6426,6 @@ packages:
   size: 18481352
   timestamp: 1781256034828
   python_site_packages_path: Lib/site-packages
-- conda: https://conda.anaconda.org/conda-forge/win-64/python-librt-0.13.0-py311hf893f09_0.conda
-  sha256: 4e809853306555a9108f2f2c4a3064ef7b4357e7c2e6970c9f13ee0c2b6f359f
-  md5: 5c09cdd65e33d535cc724ef56f18550a
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  run_exports: {}
-  size: 113299
-  timestamp: 1783529497931
 - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
   sha256: a2aff34027aa810ff36a190b75002d2ff6f9fbef71ec66e567616ac3a679d997
   md5: 0cd9b88826d0f8db142071eb830bce56
@@ -6406,6 +6604,16 @@ packages:
   - plum-dispatch>=2.5.7 ; python_full_version < '3.14'
   - plum-dispatch>=2.9.0 ; python_full_version >= '3.14'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/63/01/eee83f936500e3e0100ac421483fa78768fec70214e4ce0241187ec3a2f1/plum_dispatch-2.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: plum-dispatch
+  version: 2.9.0
+  sha256: f4d34cab84908abbdff501e356296eba960ff5d5fc04668b71ebc6f9ff84fa2f
+  requires_dist:
+  - beartype>=0.16.2 ; python_full_version < '3.14'
+  - beartype>=0.22.2 ; python_full_version >= '3.14'
+  - rich>=10.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl
   name: plum-dispatch
   version: 2.9.0
@@ -6573,6 +6781,16 @@ packages:
   name: plum-dispatch
   version: 2.9.0
   sha256: 78987caf558fbdd675a7a4a5c144069f1f9524610195123fb7d0f0234d0af01a
+  requires_dist:
+  - beartype>=0.16.2 ; python_full_version < '3.14'
+  - beartype>=0.22.2 ; python_full_version >= '3.14'
+  - rich>=10.0
+  - typing-extensions>=4.9.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e0/20/7aa36a01b1689d427a9fc20c80b1c0bc8340d1413c8071f08fb1e9a01939/plum_dispatch-2.9.0-cp311-cp311-macosx_10_9_x86_64.whl
+  name: plum-dispatch
+  version: 2.9.0
+  sha256: 25f62c2209b7bff00c6cdc25fe153ac09df304d7d833fab2852fc46fffbb7e87
   requires_dist:
   - beartype>=0.16.2 ; python_full_version < '3.14'
   - beartype>=0.22.2 ; python_full_version >= '3.14'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,24 @@ lint = "ruff check ."
 fmt = "ruff format ."
 fmt-check = "ruff format --check ."
 
+# The type feature includes the JAX stack so mypy --strict can check
+# src/duq/jax and tests/jax; conda-forge ships no win-64 jax, hence the
+# platform restriction (CI type-checks on ubuntu).
+[tool.pixi.feature.type]
+platforms = ["osx-64", "osx-arm64", "linux-64"]
+
 [tool.pixi.feature.type.dependencies]
 mypy = "*"
 numpy = ">=1.26"
+jax = ">=0.5"
+equinox = ">=0.11"
 # Present so mypy can resolve the (typed) test-suite imports under --strict.
 pytest = "*"
 hypothesis = "*"
+packaging = "*"
+
+[tool.pixi.feature.type.pypi-dependencies]
+quax = ">=0.3.6,<0.5"
 
 [tool.pixi.feature.type.tasks]
 typecheck = "mypy"
@@ -114,6 +126,12 @@ equinox = ">=0.11"
 # quax is not packaged on conda-forge, so it comes from PyPI; the upper bound
 # mirrors the pyproject [project.optional-dependencies] jax pin.
 quax = ">=0.3.6,<0.5"
+
+[tool.pixi.feature.jax.tasks]
+# The global coverage gate (95%) omits duq/jax (unimportable without jax);
+# this task runs the whole suite with jax installed and enforces a dedicated
+# >=90% gate on src/duq/jax via its own coverage config.
+test-jax = { cmd = "pytest --cov --cov-config=coverage-jax.toml", default-environment = "test-jax" }
 
 # NumPy 1.26 pin: guards the NEP-13/18 behaviour differences (and the
 # trapz/trapezoid rename) between NumPy 1.26 and 2.x on the minimum Python.
@@ -220,6 +238,9 @@ xfail_strict = true
 [tool.coverage.run]
 source = ["duq"]
 branch = true
+# duq/jax cannot import (or be measured) without the optional jax stack; the
+# test-jax task gates it separately at >=90% via coverage-jax.toml.
+omit = ["*/duq/jax/*"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ classifiers = [
 dependencies = ["numpy>=1.26"]
 
 [project.optional-dependencies]
-jax = ["jax>=0.5"]
+# quax is single-maintainer and on the 0.3.x line (research report Risk #4), so
+# it is pinned with an upper bound; equinox provides the Module/pytree base quax
+# builds on.
+jax = ["jax>=0.5", "quax>=0.3.6,<0.5", "equinox>=0.11"]
 
 [project.urls]
 Repository = "https://github.com/AAriam/duq"
@@ -104,6 +107,13 @@ platforms = ["osx-64", "osx-arm64", "linux-64"]
 
 [tool.pixi.feature.jax.dependencies]
 jax = ">=0.5"
+# equinox is on conda-forge; quax is not, so it is added below as a PyPI dep.
+equinox = ">=0.11"
+
+[tool.pixi.feature.jax.pypi-dependencies]
+# quax is not packaged on conda-forge, so it comes from PyPI; the upper bound
+# mirrors the pyproject [project.optional-dependencies] jax pin.
+quax = ">=0.3.6,<0.5"
 
 # NumPy 1.26 pin: guards the NEP-13/18 behaviour differences (and the
 # trapz/trapezoid rename) between NumPy 1.26 and 2.x on the minimum Python.

--- a/src/duq/__init__.py
+++ b/src/duq/__init__.py
@@ -29,7 +29,7 @@ from ._errors import (
     UnitParseError,
     UnsupportedOperationError,
 )
-from ._quantity import Quantity, uconvert, ustrip
+from ._quantity import Quantity, QuantityLike, uconvert, ustrip
 from ._registry import UnitRegistry, default_registry
 from ._unit import Unit
 
@@ -40,6 +40,7 @@ __all__ = (
     "DimensionalityError",
     "DuqError",
     "Quantity",
+    "QuantityLike",
     "RegistryMismatchError",
     "UndefinedUnitError",
     "Unit",

--- a/src/duq/_arraytypes.py
+++ b/src/duq/_arraytypes.py
@@ -18,10 +18,34 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 __all__ = (
+    "is_jax_like",
     "is_numpy_array",
     "is_numpy_magnitude",
     "numpy_if_loaded",
 )
+
+
+def is_jax_like(value: object) -> bool:
+    """Return whether ``value`` looks like a JAX array or tracer, without importing JAX.
+
+    The test is a cheap module-name sniff (``type(value).__module__`` starting
+    with ``"jax"``): a concrete JAX array lives in ``jaxlib._jax`` and a tracer in
+    ``jax._src.*``, both of which start with ``"jax"``, while NumPy arrays
+    (``numpy``) and Python scalars (``builtins``/``fractions``/``decimal``) do
+    not.  This lets the pure core reject JAX magnitudes -- pointing the user at
+    :class:`duq.jax.Quantity` -- without adding a JAX import.
+
+    Parameters
+    ----------
+    value : object
+        The object to test.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``value``'s type is defined in a ``jax``/``jaxlib`` module.
+    """
+    return type(value).__module__.startswith("jax")
 
 
 def numpy_if_loaded() -> ModuleType | None:

--- a/src/duq/_quantity.py
+++ b/src/duq/_quantity.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import math
 from decimal import Decimal
 from fractions import Fraction
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Protocol, TypeVar, cast, overload
 
 from ._arraytypes import is_jax_like, is_numpy_array, is_numpy_magnitude
 from ._dimension import Dimension, _coerce_exponent
@@ -30,7 +30,7 @@ from ._registry import default_registry
 from ._rules import Rule, apply
 from ._unit import Factor, Unit
 
-__all__ = ("Quantity", "uconvert", "ustrip")
+__all__ = ("Quantity", "QuantityLike", "uconvert", "ustrip")
 
 Number = int | float | complex | Fraction | Decimal
 """The scalar value types accepted by :class:`Quantity`."""
@@ -974,20 +974,50 @@ class Quantity:
         return f"{self._value} {self._unit}"
 
 
-def uconvert(unit: str | Unit, q: Quantity) -> Quantity:
+class QuantityLike(Protocol):
+    """Structural protocol for unit-carrying values.
+
+    Both the core :class:`Quantity` and the JAX-backed
+    :class:`duq.jax.Quantity` satisfy this protocol, so the free functions
+    :func:`uconvert` and :func:`ustrip` dispatch on every quantity flavour
+    without the core ever importing an array library.
+    """
+
+    @property
+    def unit(self) -> Unit:
+        """Return the unit."""
+        ...  # pragma: no cover - protocol stub
+
+    @property
+    def value(self) -> Any:
+        """Return the numeric magnitude."""
+        ...  # pragma: no cover - protocol stub
+
+    def to(self, unit: str | Unit) -> QuantityLike:
+        """Convert to another unit of the same dimension."""
+        ...  # pragma: no cover - protocol stub
+
+
+QuantityT = TypeVar("QuantityT", bound=QuantityLike)
+
+
+def uconvert(unit: str | Unit, q: QuantityT) -> QuantityT:
     """Convert a quantity to a unit (unit-first, JAX-idiomatic).
+
+    Dispatches structurally on any :class:`QuantityLike` value, so it works
+    for the core :class:`Quantity` and for :class:`duq.jax.Quantity` alike.
 
     Parameters
     ----------
     unit : str or Unit
         The target unit.
-    q : Quantity
+    q : Quantity or duq.jax.Quantity
         The quantity to convert.
 
     Returns
     -------
-    Quantity
-        The converted quantity.
+    Quantity or duq.jax.Quantity
+        The converted quantity (same flavour as ``q``).
 
     Examples
     --------
@@ -995,22 +1025,29 @@ def uconvert(unit: str | Unit, q: Quantity) -> Quantity:
     >>> duq.uconvert("cm", duq.Quantity(1.0, "m")).value
     100.0
     """
-    return q.to(unit)
+    return cast("QuantityT", q.to(unit))
 
 
-def ustrip(unit: str | Unit, q: Quantity) -> Magnitude:
+@overload
+def ustrip(unit: str | Unit, q: Quantity) -> Magnitude: ...
+@overload
+def ustrip(unit: str | Unit, q: QuantityLike) -> Any: ...
+def ustrip(unit: str | Unit, q: QuantityLike) -> Any:
     """Return a quantity's magnitude in a unit (unit-first, JAX-idiomatic).
+
+    Dispatches structurally on any :class:`QuantityLike` value, so it works
+    for the core :class:`Quantity` and for :class:`duq.jax.Quantity` alike.
 
     Parameters
     ----------
     unit : str or Unit
         The target unit.
-    q : Quantity
+    q : Quantity or duq.jax.Quantity
         The quantity to strip.
 
     Returns
     -------
-    int, float, complex, fractions.Fraction, decimal.Decimal or numpy.ndarray
+    int, float, complex, fractions.Fraction, decimal.Decimal, numpy.ndarray or jax.Array
         The bare magnitude in ``unit``.
 
     Examples

--- a/src/duq/_quantity.py
+++ b/src/duq/_quantity.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any, Final
 
-from ._arraytypes import is_numpy_array, is_numpy_magnitude
+from ._arraytypes import is_jax_like, is_numpy_array, is_numpy_magnitude
 from ._dimension import Dimension, _coerce_exponent
 from ._errors import (
     AffineUnitError,
@@ -215,6 +215,12 @@ class Quantity:
             isinstance(value, int | float | complex | Fraction | Decimal)
             or is_numpy_magnitude(value)
         ):
+            if is_jax_like(value):
+                raise TypeError(
+                    "duq.Quantity cannot wrap a JAX array or tracer; use "
+                    "duq.jax.Quantity for jit/grad/vmap-safe unit-carrying arrays "
+                    "(pip install duq[jax])"
+                )
             raise TypeError(
                 f"value must be int, float, complex, Fraction, Decimal or a NumPy "
                 f"array, not {type(value).__name__}"

--- a/src/duq/jax/__init__.py
+++ b/src/duq/jax/__init__.py
@@ -1,0 +1,96 @@
+"""JAX back-end for duq: jit/grad/vmap-safe unit-carrying arrays.
+
+:class:`duq.jax.Quantity` couples a JAX array magnitude with a static
+:class:`duq.Unit`.  Units are checked and propagated at *trace time* through
+quax primitive interception, so a compiled kernel pays zero runtime cost for
+its units.  ``import duq`` never imports JAX; this subpackage requires the
+``duq[jax]`` extra (``pip install duq[jax]``).
+
+Construction
+------------
+Build quantities from anything :func:`jax.numpy.asarray` accepts, convert
+with :meth:`~duq.jax.Quantity.to`, and cross over to the NumPy-backed core
+with :meth:`~duq.jax.Quantity.from_core` / :meth:`~duq.jax.Quantity.to_core`:
+
+>>> import duq.jax
+>>> q = duq.jax.Quantity([1.0, 2.0, 3.0], "m")
+>>> q.to("cm").value
+Array([100., 200., 300.], dtype=float32)
+
+Operators work eagerly and under every transformation; ``duq.jax.numpy``
+mirrors :mod:`jax.numpy` with unit awareness:
+
+>>> import duq.jax.numpy as djnp
+>>> str(djnp.sqrt(q * q).unit)
+'m'
+
+Transformations
+---------------
+A quantity is a pytree whose magnitude is the traced leaf and whose unit is
+static metadata, so plain :func:`jax.jit`, :func:`jax.vmap`,
+:func:`jax.lax.scan` and friends accept quantity arguments directly.
+:func:`duq.jax.grad` (and ``jacfwd``/``jacrev``/``hessian``) additionally
+label derivative outputs with the exact ``unit_out / unit_in`` unit:
+
+>>> import jax.numpy as jnp
+>>> def kinetic(v):
+...     return 0.5 * duq.jax.Quantity(2.0, "kg") * v * v
+>>> g = duq.jax.grad(kinetic)(duq.jax.Quantity(3.0, "m/s"))
+>>> g.unit == duq.unit("J") / duq.unit("m/s")
+True
+
+Retracing
+---------
+The unit is part of the pytree structure, hence part of ``jit``'s cache key:
+calling a jitted function with metres and then with kilometres compiles
+twice.  Call sites with a fixed unit are compiled once and reused.  For hot
+kernels, strip to a canonical unit *before* entering the kernel::
+
+    mag = duq.ustrip("m", q)          # plain jax.Array, no unit bookkeeping
+    out = duq.jax.Quantity(hot_kernel(mag), "m/s")
+
+Known limitations
+-----------------
+- ``jax.custom_vjp`` is not supported by quax (``custom_jvp`` is); strip
+  units around a ``custom_vjp`` boundary with :func:`duq.ustrip`.
+- Uncovered primitives fail loud with
+  :class:`~duq.UnsupportedOperationError` naming the primitive; see
+  ``docs/dev/jax_coverage.md`` for the covered set.
+- Mixing quantities *created inside* a ``quax.quaxify``-transformed function
+  with that function's traced arguments splits the unit bookkeeping across
+  trace levels; prefer the :func:`duq.jax.grad`-family wrappers, or pass all
+  quantities as arguments when using raw ``quax.quaxify``.
+"""
+
+from __future__ import annotations
+
+try:
+    import equinox  # noqa: F401  (import order: lightest first)
+    import jax  # noqa: F401
+    import quax  # noqa: F401
+except ImportError as exc:  # pragma: no cover - exercised via subprocess test
+    raise ImportError(
+        "duq.jax requires the optional JAX dependencies (jax, quax, equinox); "
+        "install them with:  pip install 'duq[jax]'"
+    ) from exc
+
+from duq._quantity import uconvert, ustrip
+
+from . import numpy
+from ._primitives import PRIMITIVE_COVERAGE
+from ._quantity import Quantity
+from ._transforms import grad, hessian, jacfwd, jacrev, jit, vmap
+
+__all__ = (
+    "PRIMITIVE_COVERAGE",
+    "Quantity",
+    "grad",
+    "hessian",
+    "jacfwd",
+    "jacrev",
+    "jit",
+    "numpy",
+    "uconvert",
+    "ustrip",
+    "vmap",
+)

--- a/src/duq/jax/_primitives.py
+++ b/src/duq/jax/_primitives.py
@@ -1,0 +1,780 @@
+"""The quax primitive rules: ``jax.lax`` primitive -> duq unit rule.
+
+Each rule strips its operands to bare magnitudes, applies the unit rule from
+:mod:`duq._rules` (or direct unit algebra), binds the underlying primitive on
+the magnitudes, and re-boxes the result.  Uncovered primitives fail loud via
+:meth:`duq.jax.Quantity.default`, naming the primitive.
+
+Plain (unit-free) operands mirror the NumPy layer's policy: arithmetic
+accepts them only where the reference quantity is dimensionless, and rejects
+them otherwise.  Two JAX-specific relaxations keep the ``jax.numpy``
+compositions (``trunc``, ``remainder``, ``var``, ``isinf``, ``pad``, ...)
+working, since they inject plain literals at the primitive level:
+
+- comparisons accept a *concrete* plain operand whose elements are all
+  scale-invariant (``0``, ``±inf`` or ``nan``) against any linear unit;
+- the structural combination primitives (``select_n``, ``pad``,
+  ``dynamic_update_slice``, ``scatter*``) let a plain operand adopt the
+  reference quantity's unit (unxt-parity), because their internal literals
+  are already traced inside jit and cannot be inspected.
+"""
+
+from __future__ import annotations
+
+import math
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.core
+import jax.numpy as jnp
+import numpy as np
+import quax
+from jax import lax
+from jax.typing import ArrayLike
+
+from duq._dimension import Dimension, _coerce_exponent
+from duq._errors import (
+    AffineUnitError,
+    DimensionalityError,
+    UnsupportedOperationError,
+)
+from duq._rules import Rule, apply
+from duq._unit import Unit
+
+from ._quantity import Quantity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+__all__ = ("PRIMITIVE_COVERAGE",)
+
+_DIMENSIONLESS = Dimension({})
+
+#: Registered primitive names -> short unit-rule description (drives the
+#: coverage table in ``docs/dev/jax_coverage.md`` and its sync test).
+_COVERAGE: dict[str, str] = {}
+
+
+def _record(primitive: Any, description: str) -> None:
+    """Record a registered primitive for the coverage table."""
+    _COVERAGE[str(primitive.name)] = description
+
+
+# -- small helpers -------------------------------------------------------------
+
+
+def _mag(x: object) -> Any:
+    """Return the raw magnitude of a Quantity, or ``x`` unchanged."""
+    return x.magnitude if isinstance(x, Quantity) else x
+
+
+def _unit_of(x: object) -> Unit | None:
+    """Return the unit of a Quantity, or ``None`` for a plain operand."""
+    return x.unit if isinstance(x, Quantity) else None
+
+
+def _dim_of(x: object) -> Dimension:
+    """Return the dimension of a Quantity, or dimensionless for a plain operand."""
+    return x.dimension if isinstance(x, Quantity) else _DIMENSIONLESS
+
+
+def _registry_of(*xs: object) -> Any:
+    """Return the registry of the first Quantity among ``xs``."""
+    for x in xs:
+        if isinstance(x, Quantity):
+            return x.unit.registry
+    raise UnsupportedOperationError(
+        "expected at least one duq.jax.Quantity operand"
+    )  # pragma: no cover - rules dispatch only with a Quantity operand
+
+
+def _dimensionless(*xs: object) -> Unit:
+    """Return the bare dimensionless unit of the operands' registry."""
+    return _registry_of(*xs).unit("1")  # type: ignore[no-any-return]
+
+
+def _radian(*xs: object) -> Unit:
+    """Return the radian unit of the operands' registry."""
+    return _registry_of(*xs).unit("rad")  # type: ignore[no-any-return]
+
+
+def _convert_mag(mag: Any, src: Unit, tgt: Unit) -> Any:
+    """Convert a bare magnitude from ``src`` to ``tgt`` using float scale/offset."""
+    if src.scale == tgt.scale and src.offset == tgt.offset:
+        return mag
+    s, s_off = float(src.scale), float(src.offset)
+    t, t_off = float(tgt.scale), float(tgt.offset)
+    return (mag * s + s_off - t_off) / t
+
+
+def _is_scale_invariant(x: object) -> bool:
+    """Return whether ``x`` is a concrete plain operand of only 0/±inf/nan."""
+    if isinstance(x, Quantity | jax.core.Tracer):
+        return False
+    arr = np.asarray(x)
+    if arr.dtype == np.bool_:
+        return not bool(arr.any())
+    if np.issubdtype(arr.dtype, np.floating) or np.issubdtype(arr.dtype, np.complexfloating):
+        return bool(np.all(np.isnan(arr) | np.isinf(arr) | (arr == 0)))
+    return bool(np.all(arr == 0))
+
+
+def _to_unit(x: object, unit: Unit, *, invariant_ok: bool = False) -> Any:
+    """Convert operand ``x`` to ``unit`` and return its bare magnitude.
+
+    A plain operand is accepted as-is when ``unit`` is dimensionless (NumPy
+    layer parity), or -- when ``invariant_ok`` -- when it is concrete and
+    scale-invariant (all 0/±inf/nan) against a non-affine unit.
+    """
+    if isinstance(x, Quantity):
+        apply(Rule.SAME_DIM, x.dimension, unit.dimension)
+        return _convert_mag(x.magnitude, x.unit, unit)
+    if unit.is_dimensionless:
+        return x
+    if invariant_ok and not unit.is_affine and _is_scale_invariant(x):
+        return x
+    raise DimensionalityError(
+        f"cannot combine a bare array/number with a quantity of dimension {unit.dimension}"
+    )
+
+
+def _to_pure(x: object) -> Any:
+    """Return the plain dimensionless value of ``x`` (``%`` and ``deg`` rescaled)."""
+    if isinstance(x, Quantity):
+        if not x.unit.is_dimensionless:
+            raise DimensionalityError(
+                f"expected a dimensionless or angle operand, got dimension {x.unit.dimension}"
+            )
+        return x.magnitude * float(x.unit.scale)
+    return x
+
+
+def _reject_affine(*units: Unit | None, action: str = "scale") -> None:
+    """Raise :class:`AffineUnitError` if any of ``units`` is affine (e.g. ``°C``)."""
+    for unit in units:
+        if unit is not None and unit.is_affine:
+            raise AffineUnitError(f"cannot {action} an affine quantity such as °C or °F")
+
+
+def _si_mag(q: Quantity) -> Any:
+    """Return the magnitude expressed in the coherent SI unit."""
+    return q.magnitude * float(q.unit.scale) + float(q.unit.offset)
+
+
+# -- additive / same-dimension ---------------------------------------------------
+
+
+def _add_sub(prim: Any, x: object, y: object, params: dict[str, Any], sign: int) -> Quantity:
+    """Bind an add/sub primitive under the core affine-aware policy."""
+    dl = _dimensionless(x, y)
+    qx = x if isinstance(x, Quantity) else Quantity(x, dl)
+    qy = y if isinstance(y, Quantity) else Quantity(y, dl)
+    apply(Rule.SAME_DIM, qx.dimension, qy.dimension)
+    x_affine, y_affine = qx.unit.is_affine, qy.unit.is_affine
+    if x_affine and y_affine:
+        if sign > 0:
+            raise AffineUnitError("cannot add two absolute (affine) quantities")
+        coherent = qx.unit.registry.coherent_unit(qx.dimension)
+        return Quantity(prim.bind(_si_mag(qx), _si_mag(qy), **params), coherent)
+    if y_affine:
+        raise AffineUnitError(
+            "cannot combine a relative quantity with an absolute (affine) quantity"
+        )
+    if x_affine:
+        ratio = float(qy.unit.scale) / float(qx.unit.scale)
+        return Quantity(prim.bind(qx.magnitude, qy.magnitude * ratio, **params), qx.unit)
+    return Quantity(prim.bind(qx.magnitude, _to_unit(qy, qx.unit), **params), qx.unit)
+
+
+@quax.register(lax.add_p)
+def _add_qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+    return _add_sub(lax.add_p, x, y, params, 1)
+
+
+@quax.register(lax.add_p)
+def _add_qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+    return _add_sub(lax.add_p, x, y, params, 1)
+
+
+@quax.register(lax.add_p)
+def _add_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+    return _add_sub(lax.add_p, x, y, params, 1)
+
+
+_record(lax.add_p, "same dimension; right operand converted to the left unit")
+
+
+@quax.register(lax.sub_p)
+def _sub_qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+    return _add_sub(lax.sub_p, x, y, params, -1)
+
+
+@quax.register(lax.sub_p)
+def _sub_qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+    return _add_sub(lax.sub_p, x, y, params, -1)
+
+
+@quax.register(lax.sub_p)
+def _sub_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+    return _add_sub(lax.sub_p, x, y, params, -1)
+
+
+_record(lax.sub_p, "same dimension; °C − °C yields the coherent SI difference (K)")
+
+
+def _same_dim(prim: Any, x: object, y: object, params: dict[str, Any]) -> Quantity:
+    """Bind a same-dimension primitive; the result keeps the reference unit."""
+    reference = _unit_of(x) or _unit_of(y)
+    assert reference is not None  # dispatch guarantees a Quantity operand
+    return Quantity(
+        prim.bind(_to_unit(x, reference), _to_unit(y, reference), **params), reference
+    )
+
+
+def _register_same_dim(prim: Any, description: str) -> None:
+    """Register QQ/QA/AQ same-dimension rules for ``prim``."""
+
+    @quax.register(prim)
+    def _qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+        return _same_dim(prim, x, y, params)
+
+    @quax.register(prim)
+    def _qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+        return _same_dim(prim, x, y, params)
+
+    @quax.register(prim)
+    def _aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+        return _same_dim(prim, x, y, params)
+
+    _record(prim, description)
+
+
+_register_same_dim(lax.max_p, "same dimension; unit preserved")
+_register_same_dim(lax.min_p, "same dimension; unit preserved")
+_register_same_dim(lax.rem_p, "same dimension; unit preserved")
+_register_same_dim(lax.nextafter_p, "same dimension; unit preserved")
+
+
+# -- multiplicative ----------------------------------------------------------------
+
+
+def _mul_div(prim: Any, x: object, y: object, params: dict[str, Any], *, div: bool) -> Quantity:
+    ux, uy = _unit_of(x), _unit_of(y)
+    _reject_affine(ux, uy)
+    dl = _dimensionless(x, y)
+    ux = dl if ux is None else ux
+    uy = dl if uy is None else uy
+    unit = ux / uy if div else ux * uy
+    return Quantity(prim.bind(_mag(x), _mag(y), **params), unit)
+
+
+def _register_mul_div(prim: Any, *, div: bool, description: str) -> None:
+    """Register QQ/QA/AQ multiply/divide rules for ``prim``."""
+
+    @quax.register(prim)
+    def _qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+        return _mul_div(prim, x, y, params, div=div)
+
+    @quax.register(prim)
+    def _qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+        return _mul_div(prim, x, y, params, div=div)
+
+    @quax.register(prim)
+    def _aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+        return _mul_div(prim, x, y, params, div=div)
+
+    _record(prim, description)
+
+
+_register_mul_div(lax.mul_p, div=False, description="units multiply")
+_register_mul_div(lax.div_p, div=True, description="units divide")
+
+
+@quax.register(lax.dot_general_p)
+def _dot_qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+    _reject_affine(x.unit, y.unit)
+    return Quantity(lax.dot_general_p.bind(x.magnitude, y.magnitude, **params), x.unit * y.unit)
+
+
+@quax.register(lax.dot_general_p)
+def _dot_qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+    _reject_affine(x.unit)
+    return Quantity(lax.dot_general_p.bind(x.magnitude, y, **params), x.unit)
+
+
+@quax.register(lax.dot_general_p)
+def _dot_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+    _reject_affine(y.unit)
+    return Quantity(lax.dot_general_p.bind(x, y.magnitude, **params), y.unit)
+
+
+_record(lax.dot_general_p, "units multiply (matmul/dot/einsum contractions)")
+
+
+# -- powers ------------------------------------------------------------------------
+
+
+def _concrete_exponent(y: object) -> Fraction | None:
+    """Return a uniform concrete exponent, or ``None`` when ``y`` is traced."""
+    value = _to_pure(y) if isinstance(y, Quantity) else y
+    if isinstance(value, jax.core.Tracer):
+        return None
+    arr = np.asarray(value)
+    if arr.ndim == 0:
+        return _coerce_exponent(arr.item())
+    first = arr.reshape(-1)[0].item()
+    if not bool(np.all(arr == first)):
+        raise UnsupportedOperationError(
+            "power with an array of differing exponents is unsupported: each "
+            "element would carry a different unit"
+        )
+    return _coerce_exponent(first)
+
+
+def _pow(x: object, y: object, params: dict[str, Any]) -> Quantity | Any:
+    unit = _unit_of(x)
+    exponent = _concrete_exponent(y)
+    y_mag = _to_pure(y) if isinstance(y, Quantity) else y
+    result = lax.pow_p.bind(_mag(x), y_mag, **params)
+    if unit is None:
+        return result
+    if exponent is None:
+        if unit.is_dimensionless and unit.scale == 1:
+            return Quantity(result, unit)
+        raise UnsupportedOperationError(
+            "a traced power exponent is only supported for a scale-1 "
+            "dimensionless base; the output unit would depend on a runtime value"
+        )
+    return Quantity(result, unit**exponent)
+
+
+@quax.register(lax.pow_p)
+def _pow_qq(x: Quantity, y: Quantity, **params: Any) -> Quantity | Any:
+    return _pow(x, y, params)
+
+
+@quax.register(lax.pow_p)
+def _pow_qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity | Any:
+    return _pow(x, y, params)
+
+
+@quax.register(lax.pow_p)
+def _pow_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity | Any:
+    return _pow(x, y, params)
+
+
+_record(lax.pow_p, "unit ** concrete dimensionless exponent (traced exponent rejected)")
+
+
+@quax.register(lax.integer_pow_p)
+def _integer_pow_q(x: Quantity, *, y: int) -> Quantity:
+    return Quantity(lax.integer_pow_p.bind(x.magnitude, y=y), x.unit**y)
+
+
+_record(lax.integer_pow_p, "unit ** y (static integer exponent)")
+
+
+def _register_unit_power(prim: Any, exponent: Fraction, description: str) -> None:
+    """Register a unary rule raising the unit to a fixed ``exponent``."""
+
+    @quax.register(prim)
+    def _rule(x: Quantity, **params: Any) -> Quantity:
+        return Quantity(prim.bind(x.magnitude, **params), x.unit**exponent)
+
+    _record(prim, description)
+
+
+_register_unit_power(lax.square_p, Fraction(2), "unit squared")
+_register_unit_power(lax.sqrt_p, Fraction(1, 2), "unit ** 1/2")
+_register_unit_power(lax.rsqrt_p, Fraction(-1, 2), "unit ** -1/2")
+_register_unit_power(lax.cbrt_p, Fraction(1, 3), "unit ** 1/3")
+
+
+# -- unary preserving / plain ---------------------------------------------------------
+
+
+def _register_preserve(prim: Any, description: str, *, no_affine: bool = False) -> None:
+    """Register a unary rule that preserves the operand's unit."""
+
+    @quax.register(prim)
+    def _rule(x: Quantity, **params: Any) -> Quantity:
+        if no_affine:
+            _reject_affine(x.unit, action=f"apply {prim.name} to")
+        return Quantity(prim.bind(x.magnitude, **params), x.unit)
+
+    _record(prim, description)
+
+
+_register_preserve(lax.neg_p, "unit preserved (affine rejected)", no_affine=True)
+_register_preserve(lax.abs_p, "unit preserved (affine rejected)", no_affine=True)
+_register_preserve(lax.floor_p, "unit preserved")
+_register_preserve(lax.ceil_p, "unit preserved")
+_register_preserve(lax.round_p, "unit preserved")
+_register_preserve(lax.real_p, "unit preserved")
+_register_preserve(lax.imag_p, "unit preserved")
+_register_preserve(lax.conj_p, "unit preserved")
+
+for _prim in (
+    lax.broadcast_in_dim_p,
+    lax.reshape_p,
+    lax.transpose_p,
+    lax.squeeze_p,
+    lax.rev_p,
+    lax.slice_p,
+    lax.copy_p,
+    lax.tile_p,
+    lax.convert_element_type_p,
+    lax.stop_gradient_p,
+):
+    _register_preserve(_prim, "structural; unit preserved")
+
+for _prim in (lax.reduce_sum_p, lax.reduce_max_p, lax.reduce_min_p):
+    _register_preserve(_prim, "reduction; unit preserved")
+
+for _prim in (lax.cumsum_p, lax.cummax_p, lax.cummin_p):
+    _register_preserve(_prim, "cumulative; unit preserved")
+
+
+def _register_plain_out(prim: Any, description: str) -> None:
+    """Register a unary rule that strips the unit (plain array out)."""
+
+    @quax.register(prim)
+    def _rule(x: Quantity, **params: Any) -> Any:
+        return prim.bind(x.magnitude, **params)
+
+    _record(prim, description)
+
+
+_register_plain_out(lax.sign_p, "plain array out (sign is scale-free)")
+_register_plain_out(lax.is_finite_p, "plain bool array out")
+_register_plain_out(lax.argmax_p, "plain index array out")
+_register_plain_out(lax.argmin_p, "plain index array out")
+_register_plain_out(lax.reduce_and_p, "plain bool array out")
+_register_plain_out(lax.reduce_or_p, "plain bool array out")
+_register_plain_out(lax.bitcast_convert_type_p, "plain array out (raw bits carry no unit)")
+
+
+@quax.register(lax.reduce_prod_p)
+def _reduce_prod_q(x: Quantity, *, axes: tuple[int, ...], **params: Any) -> Quantity:
+    _reject_affine(x.unit)
+    n = math.prod(x.magnitude.shape[axis] for axis in axes)
+    return Quantity(lax.reduce_prod_p.bind(x.magnitude, axes=axes, **params), x.unit**n)
+
+
+_record(lax.reduce_prod_p, "unit ** reduced_size (shapes are static)")
+
+
+@quax.register(lax.cumprod_p)
+def _cumprod_q(x: Quantity, **params: Any) -> Quantity:
+    if not (x.unit.is_dimensionless and x.unit.scale == 1):
+        raise UnsupportedOperationError(
+            "cumprod is unsupported for dimensional (or scaled-dimensionless) "
+            "quantities: each element would carry a different unit"
+        )
+    return Quantity(lax.cumprod_p.bind(x.magnitude, **params), x.unit)
+
+
+_record(lax.cumprod_p, "scale-1 dimensionless only (per-element unit is ambiguous)")
+
+
+# -- dimensionless-in and angle rules ---------------------------------------------------
+
+
+def _register_dimensionless_in(prim: Any, description: str) -> None:
+    """Register a unary rule requiring a dimensionless input (scale applied)."""
+
+    @quax.register(prim)
+    def _rule(x: Quantity, **params: Any) -> Quantity:
+        return Quantity(prim.bind(_to_pure(x), **params), _dimensionless(x))
+
+    _record(prim, description)
+
+
+for _prim in (
+    lax.exp_p,
+    lax.exp2_p,
+    lax.expm1_p,
+    lax.log_p,
+    lax.log1p_p,
+    lax.logistic_p,
+    lax.tanh_p,
+    lax.sinh_p,
+    lax.cosh_p,
+    lax.asinh_p,
+    lax.acosh_p,
+    lax.atanh_p,
+    lax.erf_p,
+    lax.erfc_p,
+    lax.erf_inv_p,
+):
+    _register_dimensionless_in(_prim, "dimensionless in (scale applied), dimensionless out")
+
+for _prim in (lax.sin_p, lax.cos_p, lax.tan_p):
+    _register_dimensionless_in(
+        _prim, "angle in (rad/deg scale-converted at trace time), dimensionless out"
+    )
+
+
+def _register_radian_out(prim: Any, description: str) -> None:
+    """Register a unary inverse-trig rule (dimensionless in, radian out)."""
+
+    @quax.register(prim)
+    def _rule(x: Quantity, **params: Any) -> Quantity:
+        return Quantity(prim.bind(_to_pure(x), **params), _radian(x))
+
+    _record(prim, description)
+
+
+_register_radian_out(lax.asin_p, "dimensionless in, radian out")
+_register_radian_out(lax.acos_p, "dimensionless in, radian out")
+_register_radian_out(lax.atan_p, "dimensionless in, radian out")
+
+
+def _atan2(x: object, y: object, params: dict[str, Any]) -> Quantity:
+    reference = _unit_of(x) or _unit_of(y)
+    assert reference is not None  # dispatch guarantees a Quantity operand
+    result = lax.atan2_p.bind(_to_unit(x, reference), _to_unit(y, reference), **params)
+    return Quantity(result, _radian(x, y))
+
+
+@quax.register(lax.atan2_p)
+def _atan2_qq(x: Quantity, y: Quantity, **params: Any) -> Quantity:
+    return _atan2(x, y, params)
+
+
+@quax.register(lax.atan2_p)
+def _atan2_qa(x: Quantity, y: ArrayLike, **params: Any) -> Quantity:
+    return _atan2(x, y, params)
+
+
+@quax.register(lax.atan2_p)
+def _atan2_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
+    return _atan2(x, y, params)
+
+
+_record(lax.atan2_p, "same dimension in, radian out")
+
+
+# -- comparisons -------------------------------------------------------------------------
+
+
+def _broadcast_bool(x: object, y: object, *, fill: bool) -> Any:
+    shape = jnp.broadcast_shapes(jnp.shape(_mag(x)), jnp.shape(_mag(y)))
+    return jnp.full(shape, fill, dtype=bool)
+
+
+def _compare(prim: Any, x: object, y: object, params: dict[str, Any], kind: str) -> Any:
+    """Bind a comparison primitive with unit conversion (plain bool array out).
+
+    ``eq``/``ne`` on incompatible dimensions produce constant all-False /
+    all-True arrays (NumPy layer parity); ordering raises.  A concrete
+    scale-invariant plain operand (all 0/±inf/nan) compares raw against any
+    linear unit -- ``jax.numpy`` compositions rely on such literals.
+    """
+    ux, uy = _unit_of(x), _unit_of(y)
+    reference = ux if ux is not None else uy
+    assert reference is not None  # dispatch guarantees a Quantity operand
+    plain = y if ux is not None else x
+    if not isinstance(plain, Quantity) and not reference.is_affine and _is_scale_invariant(plain):
+        return prim.bind(_mag(x), _mag(y), **params)
+    if _dim_of(x) != _dim_of(y):
+        if kind == "eq":
+            return _broadcast_bool(x, y, fill=False)
+        if kind == "ne":
+            return _broadcast_bool(x, y, fill=True)
+        raise DimensionalityError(
+            f"cannot order-compare quantities of dimension {_dim_of(x)} and {_dim_of(y)}"
+        )
+    return prim.bind(_to_unit(x, reference), _to_unit(y, reference), **params)
+
+
+def _register_compare(prim: Any, kind: str, description: str) -> None:
+    """Register QQ/QA/AQ comparison rules for ``prim``."""
+
+    @quax.register(prim)
+    def _qq(x: Quantity, y: Quantity, **params: Any) -> Any:
+        return _compare(prim, x, y, params, kind)
+
+    @quax.register(prim)
+    def _qa(x: Quantity, y: ArrayLike, **params: Any) -> Any:
+        return _compare(prim, x, y, params, kind)
+
+    @quax.register(prim)
+    def _aq(x: ArrayLike, y: Quantity, **params: Any) -> Any:
+        return _compare(prim, x, y, params, kind)
+
+    _record(prim, description)
+
+
+_register_compare(lax.eq_p, "eq", "converted compare; incompatible dims -> all-False")
+_register_compare(lax.ne_p, "ne", "converted compare; incompatible dims -> all-True")
+_register_compare(lax.lt_p, "order", "converted compare; incompatible dims raise")
+_register_compare(lax.le_p, "order", "converted compare; incompatible dims raise")
+_register_compare(lax.gt_p, "order", "converted compare; incompatible dims raise")
+_register_compare(lax.ge_p, "order", "converted compare; incompatible dims raise")
+_register_compare(lax.eq_to_p, "eq", "total-order compare (converted)")
+_register_compare(lax.lt_to_p, "order", "total-order compare (converted)")
+_register_compare(lax.le_to_p, "order", "total-order compare (converted)")
+
+
+# -- n-ary structure ----------------------------------------------------------------------
+
+
+def _first_unit(xs: Sequence[object]) -> Unit | None:
+    for x in xs:
+        if isinstance(x, Quantity):
+            return x.unit
+    return None
+
+
+@quax.register(lax.concatenate_p)
+def _concatenate(*xs: Quantity | ArrayLike, **params: Any) -> Quantity | Any:
+    unit = _first_unit(xs)
+    if unit is None:
+        return lax.concatenate_p.bind(*xs, **params)
+    mags = [_to_unit(x, unit) for x in xs]
+    return Quantity(lax.concatenate_p.bind(*mags, **params), unit)
+
+
+_record(lax.concatenate_p, "all operands converted to the first quantity's unit")
+
+
+@quax.register(lax.stack_p)
+def _stack(*xs: Quantity | ArrayLike, **params: Any) -> Quantity | Any:
+    unit = _first_unit(xs)
+    if unit is None:
+        return lax.stack_p.bind(*xs, **params)
+    mags = [_to_unit(x, unit) for x in xs]
+    return Quantity(lax.stack_p.bind(*mags, **params), unit)
+
+
+_record(lax.stack_p, "all operands converted to the first quantity's unit")
+
+
+@quax.register(lax.select_n_p)
+def _select_n(pred: ArrayLike, *cases: Quantity | ArrayLike, **params: Any) -> Quantity | Any:
+    # Plain branches pass raw and adopt the reference unit (unxt-parity): the
+    # jax.numpy compositions (var, hypot, trunc, take, ...) select against
+    # internal literals that are already traced inside jit and cannot be
+    # inspected for scale invariance.
+    unit = _first_unit(cases)
+    if unit is None:
+        return lax.select_n_p.bind(pred, *cases, **params)
+    mags = [_to_unit(case, unit) if isinstance(case, Quantity) else case for case in cases]
+    return Quantity(lax.select_n_p.bind(pred, *mags, **params), unit)
+
+
+_record(
+    lax.select_n_p,
+    "quantity branches converted to the first quantity's unit; plain branches "
+    "adopt it; predicate plain",
+)
+
+
+@quax.register(lax.sort_p)
+def _sort(*xs: Quantity | ArrayLike, **params: Any) -> list[Any]:
+    units = [_unit_of(x) for x in xs]
+    outs = lax.sort_p.bind(*(_mag(x) for x in xs), **params)
+    return [
+        Quantity(out, unit) if unit is not None else out
+        for out, unit in zip(outs, units, strict=True)
+    ]
+
+
+_record(lax.sort_p, "per-operand; each output keeps its operand's unit")
+
+
+@quax.register(lax.split_p)
+def _split(x: Quantity, **params: Any) -> list[Any]:
+    outs = lax.split_p.bind(x.magnitude, **params)
+    return [Quantity(out, x.unit) for out in outs]
+
+
+_record(lax.split_p, "structural; unit preserved on every output")
+
+
+@quax.register(lax.pad_p)
+def _pad_qq(x: Quantity, padding_value: Quantity, **params: Any) -> Quantity:
+    return Quantity(
+        lax.pad_p.bind(x.magnitude, _to_unit(padding_value, x.unit), **params), x.unit
+    )
+
+
+@quax.register(lax.pad_p)
+def _pad_qa(x: Quantity, padding_value: ArrayLike, **params: Any) -> Quantity:
+    # A plain padding value adopts the operand's unit (unxt parity):
+    # ``jnp.pad``'s default zero is already traced inside its internal jit.
+    return Quantity(lax.pad_p.bind(x.magnitude, padding_value, **params), x.unit)
+
+
+_record(lax.pad_p, "quantity padding value converted to the operand's unit; plain adopts it")
+
+
+# -- indexing ---------------------------------------------------------------------------
+
+
+@quax.register(lax.gather_p)
+def _gather(x: Quantity, indices: ArrayLike, **params: Any) -> Quantity:
+    return Quantity(lax.gather_p.bind(x.magnitude, indices, **params), x.unit)
+
+
+_record(lax.gather_p, "indexing; unit preserved")
+
+
+@quax.register(lax.dynamic_slice_p)
+def _dynamic_slice(x: Quantity, *starts: ArrayLike, **params: Any) -> Quantity:
+    return Quantity(lax.dynamic_slice_p.bind(x.magnitude, *starts, **params), x.unit)
+
+
+_record(lax.dynamic_slice_p, "indexing; unit preserved")
+
+
+@quax.register(lax.dynamic_update_slice_p)
+def _dus_qq(x: Quantity, update: Quantity, *starts: ArrayLike, **params: Any) -> Quantity:
+    mag = _to_unit(update, x.unit)
+    return Quantity(lax.dynamic_update_slice_p.bind(x.magnitude, mag, *starts, **params), x.unit)
+
+
+@quax.register(lax.dynamic_update_slice_p)
+def _dus_qa(x: Quantity, update: ArrayLike, *starts: ArrayLike, **params: Any) -> Quantity:
+    # A plain update adopts the operand's unit (unxt parity; see ``_select_n``).
+    return Quantity(
+        lax.dynamic_update_slice_p.bind(x.magnitude, update, *starts, **params), x.unit
+    )
+
+
+_record(
+    lax.dynamic_update_slice_p,
+    "quantity update converted to the operand's unit; plain update adopts it",
+)
+
+
+def _register_scatter(prim: Any, description: str) -> None:
+    """Register scatter rules converting the updates to the operand's unit."""
+
+    @quax.register(prim)
+    def _qq(x: Quantity, indices: ArrayLike, updates: Quantity, **params: Any) -> Quantity:
+        mag = _to_unit(updates, x.unit)
+        return Quantity(prim.bind(x.magnitude, indices, mag, **params), x.unit)
+
+    @quax.register(prim)
+    def _qa(x: Quantity, indices: ArrayLike, updates: ArrayLike, **params: Any) -> Quantity:
+        # Plain updates adopt the operand's unit (unxt parity; see ``_select_n``).
+        return Quantity(prim.bind(x.magnitude, indices, updates, **params), x.unit)
+
+    _record(prim, description)
+
+
+_SCATTER_RULE = "quantity updates converted to the operand's unit; plain updates adopt it"
+_register_scatter(lax.scatter_p, _SCATTER_RULE)
+_register_scatter(lax.scatter_add_p, _SCATTER_RULE)
+_register_scatter(lax.scatter_sub_p, _SCATTER_RULE)
+_register_scatter(lax.scatter_min_p, _SCATTER_RULE)
+_register_scatter(lax.scatter_max_p, _SCATTER_RULE)
+
+
+#: Immutable coverage table: (primitive name, unit-rule description) pairs,
+#: sorted by primitive name.  Control-flow primitives (``cond``/``while``/
+#: ``scan``/``pjit``) are handled by quax itself and are not listed here.
+PRIMITIVE_COVERAGE: tuple[tuple[str, str], ...] = tuple(sorted(_COVERAGE.items()))

--- a/src/duq/jax/_primitives.py
+++ b/src/duq/jax/_primitives.py
@@ -45,7 +45,7 @@ from duq._unit import Unit
 from ._quantity import Quantity
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Iterable
 
 __all__ = ("PRIMITIVE_COVERAGE",)
 
@@ -220,16 +220,14 @@ def _sub_aq(x: ArrayLike, y: Quantity, **params: Any) -> Quantity:
     return _add_sub(lax.sub_p, x, y, params, -1)
 
 
-_record(lax.sub_p, "same dimension; °C − °C yields the coherent SI difference (K)")
+_record(lax.sub_p, "same dimension; degC - degC yields the coherent SI difference (K)")
 
 
 def _same_dim(prim: Any, x: object, y: object, params: dict[str, Any]) -> Quantity:
     """Bind a same-dimension primitive; the result keeps the reference unit."""
     reference = _unit_of(x) or _unit_of(y)
     assert reference is not None  # dispatch guarantees a Quantity operand
-    return Quantity(
-        prim.bind(_to_unit(x, reference), _to_unit(y, reference), **params), reference
-    )
+    return Quantity(prim.bind(_to_unit(x, reference), _to_unit(y, reference), **params), reference)
 
 
 def _register_same_dim(prim: Any, description: str) -> None:
@@ -621,7 +619,7 @@ _register_compare(lax.le_to_p, "order", "total-order compare (converted)")
 # -- n-ary structure ----------------------------------------------------------------------
 
 
-def _first_unit(xs: Sequence[object]) -> Unit | None:
+def _first_unit(xs: Iterable[object]) -> Unit | None:
     for x in xs:
         if isinstance(x, Quantity):
             return x.unit
@@ -654,11 +652,13 @@ _record(lax.stack_p, "all operands converted to the first quantity's unit")
 
 @quax.register(lax.select_n_p)
 def _select_n(pred: ArrayLike, *cases: Quantity | ArrayLike, **params: Any) -> Quantity | Any:
-    # Plain branches pass raw and adopt the reference unit (unxt-parity): the
-    # jax.numpy compositions (var, hypot, trunc, take, ...) select against
-    # internal literals that are already traced inside jit and cannot be
-    # inspected for scale invariance.
-    unit = _first_unit(cases)
+    # The reference unit is the LAST quantity case: ``jnp.where(c, x, y)``
+    # lowers to ``select_n(c, y, x)``, so this matches the NumPy layer's
+    # ``np.where`` (unit of ``x``).  Plain branches pass raw and adopt the
+    # reference unit (unxt parity): jax.numpy compositions (var, hypot,
+    # trunc, take, ...) select against internal literals that are already
+    # traced inside jit and cannot be inspected for scale invariance.
+    unit = _first_unit(reversed(cases))
     if unit is None:
         return lax.select_n_p.bind(pred, *cases, **params)
     mags = [_to_unit(case, unit) if isinstance(case, Quantity) else case for case in cases]
@@ -667,15 +667,15 @@ def _select_n(pred: ArrayLike, *cases: Quantity | ArrayLike, **params: Any) -> Q
 
 _record(
     lax.select_n_p,
-    "quantity branches converted to the first quantity's unit; plain branches "
-    "adopt it; predicate plain",
+    "quantity branches converted to the last quantity case's unit (np.where "
+    "parity); plain branches adopt it; predicate plain",
 )
 
 
 @quax.register(lax.sort_p)
 def _sort(*xs: Quantity | ArrayLike, **params: Any) -> list[Any]:
     units = [_unit_of(x) for x in xs]
-    outs = lax.sort_p.bind(*(_mag(x) for x in xs), **params)
+    outs = lax.sort_p.bind(*(_mag(x) for x in xs), **params)  # type: ignore[no-untyped-call]
     return [
         Quantity(out, unit) if unit is not None else out
         for out, unit in zip(outs, units, strict=True)
@@ -687,7 +687,7 @@ _record(lax.sort_p, "per-operand; each output keeps its operand's unit")
 
 @quax.register(lax.split_p)
 def _split(x: Quantity, **params: Any) -> list[Any]:
-    outs = lax.split_p.bind(x.magnitude, **params)
+    outs = lax.split_p.bind(x.magnitude, **params)  # type: ignore[no-untyped-call]
     return [Quantity(out, x.unit) for out in outs]
 
 
@@ -696,9 +696,7 @@ _record(lax.split_p, "structural; unit preserved on every output")
 
 @quax.register(lax.pad_p)
 def _pad_qq(x: Quantity, padding_value: Quantity, **params: Any) -> Quantity:
-    return Quantity(
-        lax.pad_p.bind(x.magnitude, _to_unit(padding_value, x.unit), **params), x.unit
-    )
+    return Quantity(lax.pad_p.bind(x.magnitude, _to_unit(padding_value, x.unit), **params), x.unit)
 
 
 @quax.register(lax.pad_p)

--- a/src/duq/jax/_quantity.py
+++ b/src/duq/jax/_quantity.py
@@ -1,0 +1,516 @@
+"""The JAX :class:`Quantity`: a quax ``ArrayValue`` with a static unit.
+
+The magnitude is the traced pytree leaf; the unit is static metadata
+(``equinox.field(static=True)``), so it participates in ``jit``'s cache key
+and is checked at trace time.  ``materialise()`` refuses, which is what makes
+uncovered primitives fail loud instead of silently dropping units.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any
+
+import equinox as eqx
+import jax
+import jax.core
+import jax.numpy as jnp
+import quax
+
+from duq._errors import (
+    AffineUnitError,
+    DimensionalityError,
+    UnsupportedOperationError,
+)
+from duq._quantity import Quantity as CoreQuantity
+from duq._quantity import _avogadro_power
+from duq._registry import default_registry
+from duq._rules import Rule, apply
+from duq._unit import Unit
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from duq._dimension import Dimension
+
+__all__ = ("Quantity",)
+
+
+def _quaxed(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a ``jax.numpy`` function once with :func:`quax.quaxify`."""
+    return quax.quaxify(fn)
+
+
+# Memoised quaxified jnp entry points backing the Python operators.
+_add = _quaxed(jnp.add)
+_subtract = _quaxed(jnp.subtract)
+_multiply = _quaxed(jnp.multiply)
+_divide = _quaxed(jnp.divide)
+_floor_divide = _quaxed(jnp.floor_divide)
+_remainder = _quaxed(jnp.remainder)
+_power = _quaxed(jnp.power)
+_matmul = _quaxed(jnp.matmul)
+_negative = _quaxed(jnp.negative)
+_absolute = _quaxed(jnp.absolute)
+_equal = _quaxed(jnp.equal)
+_not_equal = _quaxed(jnp.not_equal)
+_less = _quaxed(jnp.less)
+_less_equal = _quaxed(jnp.less_equal)
+_greater = _quaxed(jnp.greater)
+_greater_equal = _quaxed(jnp.greater_equal)
+
+
+def _getitem(x: Any, key: Any) -> Any:
+    return x[key]
+
+
+_quaxed_getitem = _quaxed(_getitem)
+
+
+def _is_operand(x: object) -> bool:
+    """Return whether ``x`` may appear opposite a JAX quantity in an operator."""
+    if isinstance(x, Quantity):
+        return True
+    return eqx.is_array_like(x) and not isinstance(x, CoreQuantity)
+
+
+def _reject_core_quantity(x: object) -> None:
+    if isinstance(x, CoreQuantity):
+        raise TypeError(
+            "cannot mix a core duq.Quantity with a duq.jax.Quantity; convert it "
+            "first with duq.jax.Quantity.from_core(q)"
+        )
+
+
+class Quantity(quax.ArrayValue):
+    """An immutable JAX array magnitude paired with a static physical unit.
+
+    Parameters
+    ----------
+    value : array_like
+        Anything :func:`jax.numpy.asarray` accepts (Python scalars, lists,
+        NumPy arrays, JAX arrays and tracers).  :class:`~fractions.Fraction`
+        and :class:`~decimal.Decimal` magnitudes are converted to ``float``.
+    unit : str or Unit
+        The unit; strings are parsed against the default registry.
+
+    See Also
+    --------
+    duq.Quantity : The scalar/NumPy core quantity.
+
+    Examples
+    --------
+    >>> import duq.jax
+    >>> q = duq.jax.Quantity([1.0, 2.0, 3.0], "m")
+    >>> str((q * q).unit)
+    'm²'
+    """
+
+    magnitude: jax.Array
+    unit: Unit = eqx.field(static=True)
+
+    def __init__(self, value: Any, unit: str | Unit) -> None:
+        if isinstance(value, CoreQuantity):
+            raise TypeError(
+                "cannot wrap a core duq.Quantity in a duq.jax.Quantity; use "
+                "duq.jax.Quantity.from_core(q) instead"
+            )
+        if isinstance(value, Fraction | Decimal):
+            value = float(value)
+        if isinstance(unit, str):
+            resolved = default_registry.unit(unit)
+        elif isinstance(unit, Unit):
+            resolved = unit
+        else:
+            raise TypeError(f"unit must be a str or Unit, not {type(unit).__name__}")
+        self.magnitude = jnp.asarray(value)
+        self.unit = resolved
+
+    # -- quax interface -------------------------------------------------------
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the abstract value JAX sees: the magnitude's shape and dtype."""
+        return jax.core.ShapedArray(jnp.shape(self.magnitude), jnp.result_type(self.magnitude))
+
+    def materialise(self) -> Any:
+        """Refuse to collapse to a plain array (units are never dropped silently)."""
+        raise UnsupportedOperationError(
+            "refusing to materialise a unit-carrying array, which would silently "
+            "drop its unit; use duq.ustrip(unit, q) to get the magnitude in a "
+            "chosen unit"
+        )
+
+    @staticmethod
+    def default(
+        primitive: Any, values: Sequence[Any], params: dict[str, Any]
+    ) -> Any:  # numpydoc ignore=PR01,RT01
+        """Fail loud on any JAX primitive without a registered duq unit rule."""
+        raise UnsupportedOperationError(
+            f"the JAX primitive {primitive.name!r} has no duq unit rule and is "
+            "unsupported for unit-carrying arrays; call duq.ustrip(unit, q) to "
+            "drop units explicitly first (see docs/dev/jax_coverage.md for the "
+            "covered primitives)"
+        )
+
+    # -- properties -----------------------------------------------------------
+
+    @property
+    def value(self) -> jax.Array:
+        """Return the numeric magnitude (alias of ``magnitude``)."""
+        return self.magnitude
+
+    @property
+    def dimension(self) -> Dimension:
+        """Return the physical dimension."""
+        return self.unit.dimension
+
+    # -- conversion -----------------------------------------------------------
+
+    def to(self, unit: str | Unit, *, equivalence: str | None = None) -> Quantity:
+        """Convert to another unit of the same dimension.
+
+        The conversion is ordinary traced arithmetic (scale and, for affine
+        units such as °C, shift), so it works eagerly and under ``jit``.
+
+        Parameters
+        ----------
+        unit : str or Unit
+            The target unit.
+        equivalence : {None, "molar"}, optional
+            When ``"molar"``, bridge per-amount and absolute quantities using
+            the Avogadro constant.
+
+        Returns
+        -------
+        Quantity
+            The converted quantity.
+
+        Raises
+        ------
+        DimensionalityError
+            If the dimensions are incompatible.
+
+        Examples
+        --------
+        >>> import duq.jax
+        >>> duq.jax.Quantity(1.0, "km").to("m").value
+        Array(1000., dtype=float32, weak_type=True)
+        """
+        target = self.unit.registry.unit(unit)
+        if equivalence == "molar":
+            return self._to_molar(target)
+        if equivalence is not None:
+            raise ValueError(f"unknown equivalence {equivalence!r}")
+        apply(Rule.SAME_DIM, self.dimension, target.dimension)
+        if self.unit.scale == target.scale and self.unit.offset == target.offset:
+            return Quantity(self.magnitude, target)
+        si = self.magnitude * float(self.unit.scale) + float(self.unit.offset)
+        return Quantity((si - float(target.offset)) / float(target.scale), target)
+
+    def _to_molar(self, target: Unit) -> Quantity:
+        if self.unit.is_affine or target.is_affine:
+            raise AffineUnitError(
+                "molar equivalence is undefined for affine units such as °C or °F; "
+                "convert to an absolute unit (e.g. K) first"
+            )
+        src_n = self.dimension.exponents["N"]
+        tgt_n = target.dimension.exponents["N"]
+        k = tgt_n - src_n
+        from duq._dimension import Dimension
+
+        if self.dimension * Dimension({"N": k}) != target.dimension:
+            raise DimensionalityError(
+                "molar equivalence requires the dimensions to differ only by a "
+                "power of the amount of substance"
+            )
+        factor = float(self.unit.scale) * float(_avogadro_power(-k)) / float(target.scale)
+        return Quantity(self.magnitude * factor, target)
+
+    def value_in(self, unit: str | Unit) -> jax.Array:
+        """Return the magnitude expressed in ``unit``.
+
+        Parameters
+        ----------
+        unit : str or Unit
+            The target unit.
+
+        Returns
+        -------
+        jax.Array
+            The converted magnitude.
+
+        Examples
+        --------
+        >>> import duq.jax
+        >>> duq.jax.Quantity(2.0, "m").value_in("cm")
+        Array(200., dtype=float32, weak_type=True)
+        """
+        return self.to(unit).magnitude
+
+    @classmethod
+    def from_core(cls, q: CoreQuantity) -> Quantity:
+        """Build a JAX quantity from a core :class:`duq.Quantity`.
+
+        Parameters
+        ----------
+        q : duq.Quantity
+            The core quantity; its magnitude is device-put via
+            :func:`jax.numpy.asarray` and its unit is kept as-is.
+
+        Returns
+        -------
+        Quantity
+            The JAX-backed quantity.
+
+        Examples
+        --------
+        >>> import duq, duq.jax
+        >>> duq.jax.Quantity.from_core(duq.Quantity(1.5, "kJ/mol")).unit
+        Unit('kJ.mol^-1')
+        """
+        return cls(q.value, q.unit)
+
+    def to_core(self) -> CoreQuantity:
+        """Return a core :class:`duq.Quantity` (device-to-host copy).
+
+        Returns
+        -------
+        duq.Quantity
+            A NumPy-backed core quantity with the same unit.
+
+        Examples
+        --------
+        >>> import duq.jax
+        >>> duq.jax.Quantity([1.0, 2.0], "m").to_core().is_array
+        True
+        """
+        import numpy as np
+
+        return CoreQuantity(np.asarray(self.magnitude), self.unit)
+
+    # -- scalar coercion (dimensionless converts; dimensional fails loud) -----
+
+    def _as_dimensionless(self, target: str) -> jax.Array:
+        """Return the magnitude in the bare scale-1 dimensionless unit, or fail loud."""
+        if self.unit.is_dimensionless:
+            return self.magnitude * float(self.unit.scale)
+        raise UnsupportedOperationError(
+            f"refusing to coerce a quantity of dimension {self.dimension} to a "
+            f"bare {target}, which would drop its unit; use duq.ustrip(unit, q) "
+            "to get the magnitude in a chosen unit (only dimensionless "
+            "quantities coerce directly)"
+        )
+
+    def __bool__(self) -> bool:
+        """Return the truthiness of a dimensionless quantity's magnitude."""
+        return bool(self._as_dimensionless("bool"))
+
+    def __float__(self) -> float:
+        """Return a dimensionless quantity's magnitude as a float (scale applied)."""
+        return float(self._as_dimensionless("float"))
+
+    def __int__(self) -> int:
+        """Return a dimensionless quantity's magnitude as an int (scale applied)."""
+        return int(self._as_dimensionless("int"))
+
+    def __complex__(self) -> complex:
+        """Return a dimensionless quantity's magnitude as a complex (scale applied)."""
+        return complex(self._as_dimensionless("complex"))
+
+    def __array__(self, dtype: object = None, copy: object = None) -> Any:
+        """Refuse silent unit-stripping conversion to a bare array."""
+        raise UnsupportedOperationError(
+            "refusing to convert a duq.jax.Quantity to a bare array, which would "
+            "silently drop its unit; use duq.ustrip(unit, q) to get the magnitude "
+            "in a chosen unit (or q.value for the stored magnitude)"
+        )
+
+    # -- arithmetic operators (all route through the primitive rules) ---------
+
+    def _binary(self, fn: Callable[..., Any], a: object, b: object) -> Any:
+        _reject_core_quantity(a)
+        _reject_core_quantity(b)
+        if not (_is_operand(a) and _is_operand(b)):
+            return NotImplemented
+        return fn(a, b)
+
+    def __add__(self, other: object) -> Quantity:
+        return self._binary(_add, self, other)  # type: ignore[no-any-return]
+
+    def __radd__(self, other: object) -> Quantity:
+        return self._binary(_add, other, self)  # type: ignore[no-any-return]
+
+    def __sub__(self, other: object) -> Quantity:
+        return self._binary(_subtract, self, other)  # type: ignore[no-any-return]
+
+    def __rsub__(self, other: object) -> Quantity:
+        return self._binary(_subtract, other, self)  # type: ignore[no-any-return]
+
+    def __mul__(self, other: object) -> Quantity:
+        return self._binary(_multiply, self, other)  # type: ignore[no-any-return]
+
+    def __rmul__(self, other: object) -> Quantity:
+        return self._binary(_multiply, other, self)  # type: ignore[no-any-return]
+
+    def __truediv__(self, other: object) -> Quantity:
+        return self._binary(_divide, self, other)  # type: ignore[no-any-return]
+
+    def __rtruediv__(self, other: object) -> Quantity:
+        return self._binary(_divide, other, self)  # type: ignore[no-any-return]
+
+    def __floordiv__(self, other: object) -> Quantity:
+        return self._binary(_floor_divide, self, other)  # type: ignore[no-any-return]
+
+    def __rfloordiv__(self, other: object) -> Quantity:
+        return self._binary(_floor_divide, other, self)  # type: ignore[no-any-return]
+
+    def __mod__(self, other: object) -> Quantity:
+        return self._binary(_remainder, self, other)  # type: ignore[no-any-return]
+
+    def __rmod__(self, other: object) -> Quantity:
+        return self._binary(_remainder, other, self)  # type: ignore[no-any-return]
+
+    def __pow__(self, power: object) -> Quantity:
+        return self._binary(_power, self, power)  # type: ignore[no-any-return]
+
+    def __matmul__(self, other: object) -> Quantity:
+        return self._binary(_matmul, self, other)  # type: ignore[no-any-return]
+
+    def __rmatmul__(self, other: object) -> Quantity:
+        return self._binary(_matmul, other, self)  # type: ignore[no-any-return]
+
+    def __neg__(self) -> Quantity:
+        result: Quantity = _negative(self)
+        return result
+
+    def __pos__(self) -> Quantity:
+        return self
+
+    def __abs__(self) -> Quantity:
+        result: Quantity = _absolute(self)
+        return result
+
+    # -- comparisons (plain bool arrays out) -----------------------------------
+
+    def __eq__(self, other: object) -> jax.Array:  # type: ignore[override]
+        return self._binary(_equal, self, other)  # type: ignore[no-any-return]
+
+    def __ne__(self, other: object) -> jax.Array:  # type: ignore[override]
+        return self._binary(_not_equal, self, other)  # type: ignore[no-any-return]
+
+    def __lt__(self, other: object) -> jax.Array:
+        return self._binary(_less, self, other)  # type: ignore[no-any-return]
+
+    def __le__(self, other: object) -> jax.Array:
+        return self._binary(_less_equal, self, other)  # type: ignore[no-any-return]
+
+    def __gt__(self, other: object) -> jax.Array:
+        return self._binary(_greater, self, other)  # type: ignore[no-any-return]
+
+    def __ge__(self, other: object) -> jax.Array:
+        return self._binary(_greater_equal, self, other)  # type: ignore[no-any-return]
+
+    # Defining __eq__ makes the class unhashable (like numpy.ndarray); the
+    # static *unit* stays hashable, which is all jit's cache key needs.
+
+    # -- array ergonomics -------------------------------------------------------
+
+    def __getitem__(self, key: object) -> Quantity:
+        """Index the magnitude, preserving the unit."""
+        result: Quantity = _quaxed_getitem(self, key)
+        return result
+
+    def __len__(self) -> int:
+        shape = self.shape
+        if not shape:
+            raise TypeError("len() of unsized object (0-d quantity)")
+        return int(shape[0])
+
+    @property
+    def at(self) -> _IndexUpdateHelper:
+        """Return the indexed-update helper (mirrors ``jax.Array.at``).
+
+        Updates are unit-checked: a :class:`Quantity` update is converted to
+        this quantity's unit before the scatter.
+
+        Examples
+        --------
+        >>> import duq.jax
+        >>> q = duq.jax.Quantity([1.0, 2.0], "m")
+        >>> q.at[0].set(duq.jax.Quantity(300.0, "cm")).value
+        Array([3., 2.], dtype=float32)
+        """
+        return _IndexUpdateHelper(self)
+
+    # -- rendering --------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return f"Quantity({self.magnitude!r}, {self.unit!r})"
+
+    def __str__(self) -> str:
+        return f"{self.magnitude} {self.unit}"
+
+
+def _make_at_op(name: str) -> Callable[..., Any]:
+    """Build a quaxified ``x.at[key].<name>(value)`` entry point."""
+
+    def apply_op(x: Any, key: Any, value: Any) -> Any:
+        return getattr(x.at[key], name)(value)
+
+    return _quaxed(apply_op)
+
+
+_AT_OPS: dict[str, Callable[..., Any]] = {
+    name: _make_at_op(name) for name in ("set", "add", "subtract", "min", "max")
+}
+
+
+class _IndexUpdateHelper:
+    """Unit-aware mirror of ``jax.Array.at`` (see :attr:`Quantity.at`)."""
+
+    __slots__ = ("_quantity",)
+
+    def __init__(self, quantity: Quantity) -> None:
+        self._quantity = quantity
+
+    def __getitem__(self, key: object) -> _IndexUpdateRef:
+        return _IndexUpdateRef(self._quantity, key)
+
+
+class _IndexUpdateRef:
+    """One pending indexed update; exposes ``set``/``add``/``subtract``/``min``/``max``."""
+
+    __slots__ = ("_key", "_quantity")
+
+    def __init__(self, quantity: Quantity, key: object) -> None:
+        self._quantity = quantity
+        self._key = key
+
+    def get(self) -> Quantity:
+        """Return the indexed elements (unit preserved)."""
+        return self._quantity[self._key]
+
+    def _apply(self, name: str, value: object) -> Quantity:
+        result: Quantity = _AT_OPS[name](self._quantity, self._key, value)
+        return result
+
+    def set(self, value: object) -> Quantity:
+        """Return a copy with the indexed elements set to ``value`` (converted)."""
+        return self._apply("set", value)
+
+    def add(self, value: object) -> Quantity:
+        """Return a copy with ``value`` (converted) added to the indexed elements."""
+        return self._apply("add", value)
+
+    def subtract(self, value: object) -> Quantity:
+        """Return a copy with ``value`` (converted) subtracted from the indexed elements."""
+        return self._apply("subtract", value)
+
+    def min(self, value: object) -> Quantity:
+        """Return a copy with the elementwise minimum of ``value`` (converted)."""
+        return self._apply("min", value)
+
+    def max(self, value: object) -> Quantity:
+        """Return a copy with the elementwise maximum of ``value`` (converted)."""
+        return self._apply("max", value)

--- a/src/duq/jax/_quantity.py
+++ b/src/duq/jax/_quantity.py
@@ -16,8 +16,10 @@ import equinox as eqx
 import jax
 import jax.core
 import jax.numpy as jnp
+import numpy as np
 import quax
 
+from duq._dimension import Dimension
 from duq._errors import (
     AffineUnitError,
     DimensionalityError,
@@ -31,8 +33,6 @@ from duq._unit import Unit
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-
-    from duq._dimension import Dimension
 
 __all__ = ("Quantity",)
 
@@ -109,6 +109,11 @@ class Quantity(quax.ArrayValue):
 
     magnitude: jax.Array
     unit: Unit = eqx.field(static=True)
+
+    #: Opt out of NumPy's ufunc machinery so ``ndarray * q`` (etc.) defers to
+    #: the reflected operators instead of calling ``np.asarray`` on the
+    #: quantity (which fails loud by design).
+    __array_ufunc__ = None
 
     def __init__(self, value: Any, unit: str | Unit) -> None:
         if isinstance(value, CoreQuantity):
@@ -217,8 +222,6 @@ class Quantity(quax.ArrayValue):
         src_n = self.dimension.exponents["N"]
         tgt_n = target.dimension.exponents["N"]
         k = tgt_n - src_n
-        from duq._dimension import Dimension
-
         if self.dimension * Dimension({"N": k}) != target.dimension:
             raise DimensionalityError(
                 "molar equivalence requires the dimensions to differ only by a "
@@ -285,8 +288,6 @@ class Quantity(quax.ArrayValue):
         >>> duq.jax.Quantity([1.0, 2.0], "m").to_core().is_array
         True
         """
-        import numpy as np
-
         return CoreQuantity(np.asarray(self.magnitude), self.unit)
 
     # -- scalar coercion (dimensionless converts; dimensional fails loud) -----
@@ -411,8 +412,9 @@ class Quantity(quax.ArrayValue):
     def __ge__(self, other: object) -> jax.Array:
         return self._binary(_greater_equal, self, other)  # type: ignore[no-any-return]
 
-    # Defining __eq__ makes the class unhashable (like numpy.ndarray); the
-    # static *unit* stays hashable, which is all jit's cache key needs.
+    # Array quantities are unhashable, exactly like numpy.ndarray; the static
+    # *unit* stays hashable, which is all jit's cache key needs.
+    __hash__ = None  # type: ignore[assignment]
 
     # -- array ergonomics -------------------------------------------------------
 

--- a/src/duq/jax/_transforms.py
+++ b/src/duq/jax/_transforms.py
@@ -125,7 +125,7 @@ def _is_nested_quantity(x: object) -> bool:
     return isinstance(x, Quantity) and isinstance(x.magnitude, Quantity)
 
 
-def _jacobian_like(transform: Callable[..., Any]) -> Callable[..., Any]:
+def _jacobian_like(transform: Callable[..., Any]) -> Callable[..., Callable[..., Any]]:
     """Build a unit-collapsing wrapper factory around a JAX Jacobian transform."""
 
     def factory(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:

--- a/src/duq/jax/_transforms.py
+++ b/src/duq/jax/_transforms.py
@@ -1,0 +1,273 @@
+"""Unit-aware JAX transformation wrappers.
+
+A :class:`duq.jax.Quantity` is a pytree (magnitude = traced leaf, unit =
+static), so the plain JAX transformations already accept quantities directly;
+:func:`jit` and :func:`vmap` below are documented thin aliases.  The
+derivative wrappers (:func:`grad`, :func:`jacfwd`, :func:`jacrev`,
+:func:`hessian`) additionally label their outputs with the exact
+``unit_out / unit_in`` derivative unit, which raw :func:`jax.grad` cannot do
+(it returns the gradient with the *input* pytree structure, hence the input
+unit label).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any
+
+import jax
+
+from ._quantity import Quantity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from duq._unit import Unit
+
+__all__ = ("grad", "hessian", "jacfwd", "jacrev", "jit", "vmap")
+
+
+def _is_quantity(x: object) -> bool:
+    return isinstance(x, Quantity)
+
+
+def _relabel_gradient(grads: Any, unit_out: Unit | None) -> Any:
+    """Relabel a gradient pytree: each Quantity leaf gets ``unit_out / unit_in``.
+
+    ``jax.grad`` returns the gradient with the *input* tree structure, so a
+    quantity gradient arrives labelled with the input unit.  When the
+    differentiated function returned a plain (already-stripped) scalar,
+    ``unit_out`` is ``None`` and the bare magnitudes are returned instead --
+    duq never guesses a unit it cannot know.
+    """
+
+    def relabel(leaf: Any) -> Any:
+        if isinstance(leaf, Quantity):
+            if unit_out is None:
+                return leaf.magnitude
+            return Quantity(leaf.magnitude, unit_out / leaf.unit)
+        return leaf
+
+    return jax.tree_util.tree_map(relabel, grads, is_leaf=_is_quantity)
+
+
+def grad(
+    fun: Callable[..., Any], argnums: int | tuple[int, ...] = 0, **kwargs: Any
+) -> Callable[..., Any]:
+    """Return a unit-aware gradient function (see :func:`jax.grad`).
+
+    ``fun`` may accept and return quantities; quantities may also be created
+    freely inside it.  When ``fun`` returns a :class:`~duq.jax.Quantity`, the
+    gradient of every quantity argument is labelled with the exact derivative
+    unit ``unit_out / unit_in``.  When ``fun`` returns a plain scalar (e.g.
+    after :func:`duq.ustrip`), plain gradient magnitudes are returned.
+
+    Parameters
+    ----------
+    fun : callable
+        A function returning a scalar :class:`~duq.jax.Quantity` or a plain
+        scalar array.
+    argnums : int or tuple of int, optional
+        Which positional argument(s) to differentiate with respect to.
+    **kwargs
+        Forwarded to :func:`jax.grad` (e.g. ``has_aux`` is not supported).
+
+    Returns
+    -------
+    callable
+        The gradient function.
+
+    Examples
+    --------
+    >>> import duq, duq.jax
+    >>> def kinetic(v):
+    ...     return 0.5 * duq.jax.Quantity(2.0, "kg") * v * v
+    >>> g = duq.jax.grad(kinetic)(duq.jax.Quantity(3.0, "m/s"))
+    >>> g.unit == duq.unit("J") / duq.unit("m/s")
+    True
+    """
+
+    @functools.wraps(fun)
+    def wrapper(*args: Any, **fkwargs: Any) -> Any:
+        out_struct = jax.eval_shape(fun, *args, **fkwargs)
+        if isinstance(out_struct, Quantity):
+            unit_out: Unit | None = out_struct.unit
+
+            def scalar_fun(*a: Any, **k: Any) -> Any:
+                return fun(*a, **k).magnitude
+
+        else:
+            unit_out = None
+            scalar_fun = fun
+        grads = jax.grad(scalar_fun, argnums=argnums, **kwargs)(*args, **fkwargs)
+        return _relabel_gradient(grads, unit_out)
+
+    return wrapper
+
+
+def _collapse_nested(out: Quantity) -> Quantity:
+    """Collapse a nested quantity (out-tree over in-tree) into one unit.
+
+    ``jax.jacfwd(f)(q)`` returns the *output* pytree with each leaf replaced
+    by the *input* pytree, so a quantity Jacobian arrives as
+    ``Quantity(Quantity(jac, unit_in), unit_out)``; the derivative unit is the
+    quotient of the layers.
+    """
+    unit = out.unit
+    magnitude: Any = out.magnitude
+    while isinstance(magnitude, Quantity):
+        unit = unit / magnitude.unit
+        magnitude = magnitude.magnitude
+    return Quantity(magnitude, unit)
+
+
+def _is_nested_quantity(x: object) -> bool:
+    return isinstance(x, Quantity) and isinstance(x.magnitude, Quantity)
+
+
+def _jacobian_like(transform: Callable[..., Any]) -> Callable[..., Any]:
+    """Build a unit-collapsing wrapper factory around a JAX Jacobian transform."""
+
+    def factory(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+        transformed = transform(fun, **kwargs)
+
+        @functools.wraps(fun)
+        def wrapper(*args: Any, **fkwargs: Any) -> Any:
+            out = transformed(*args, **fkwargs)
+            return jax.tree_util.tree_map(
+                lambda x: _collapse_nested(x) if isinstance(x, Quantity) else x,
+                out,
+                is_leaf=_is_nested_quantity,
+            )
+
+        return wrapper
+
+    return factory
+
+
+def jacfwd(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+    """Return a unit-aware forward-mode Jacobian function (see :func:`jax.jacfwd`).
+
+    The Jacobian of a quantity-valued function of a quantity argument is a
+    :class:`~duq.jax.Quantity` with unit ``unit_out / unit_in``.
+
+    Parameters
+    ----------
+    fun : callable
+        The function to differentiate.
+    **kwargs
+        Forwarded to :func:`jax.jacfwd`.
+
+    Returns
+    -------
+    callable
+        The Jacobian function.
+
+    Examples
+    --------
+    >>> import duq, duq.jax
+    >>> import jax.numpy as jnp
+    >>> f = lambda q: q * q
+    >>> j = duq.jax.jacfwd(f)(duq.jax.Quantity(jnp.array([1.0, 2.0]), "m"))
+    >>> j.unit == duq.unit("m")
+    True
+    """
+    return _jacobian_like(jax.jacfwd)(fun, **kwargs)
+
+
+def jacrev(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+    """Return a unit-aware reverse-mode Jacobian function (see :func:`jax.jacrev`).
+
+    Parameters
+    ----------
+    fun : callable
+        The function to differentiate.
+    **kwargs
+        Forwarded to :func:`jax.jacrev`.
+
+    Returns
+    -------
+    callable
+        The Jacobian function.
+    """
+    return _jacobian_like(jax.jacrev)(fun, **kwargs)
+
+
+def hessian(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+    """Return a unit-aware Hessian function (see :func:`jax.hessian`).
+
+    The Hessian of a quantity-valued function of a quantity argument is a
+    :class:`~duq.jax.Quantity` with unit ``unit_out / unit_in**2``.
+
+    Parameters
+    ----------
+    fun : callable
+        The function to differentiate twice.
+    **kwargs
+        Forwarded to :func:`jax.hessian`.
+
+    Returns
+    -------
+    callable
+        The Hessian function.
+    """
+    return _jacobian_like(jax.hessian)(fun, **kwargs)
+
+
+def jit(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+    """Return ``fun`` compiled with :func:`jax.jit` (quantities pass as pytrees).
+
+    A quantity's unit is static pytree metadata and therefore part of the
+    compilation cache key: call sites with a fixed unit compile once; a new
+    unit retraces.  Strip to a canonical unit with :func:`duq.ustrip` before a
+    hot kernel to avoid per-op unit bookkeeping entirely.
+
+    Parameters
+    ----------
+    fun : callable
+        The function to compile; it may accept and return quantities.
+    **kwargs
+        Forwarded to :func:`jax.jit` (``static_argnums``, ``donate_argnums``, ...).
+
+    Returns
+    -------
+    callable
+        The compiled function.
+
+    Examples
+    --------
+    >>> import duq.jax
+    >>> f = duq.jax.jit(lambda q: q * q)
+    >>> str(f(duq.jax.Quantity(3.0, "m")).unit)
+    'm²'
+    """
+    return jax.jit(fun, **kwargs)
+
+
+def vmap(fun: Callable[..., Any], **kwargs: Any) -> Callable[..., Any]:
+    """Return ``fun`` vectorised with :func:`jax.vmap` (quantities pass as pytrees).
+
+    Batching maps over the magnitude leaf; the unit is pytree structure and is
+    shared across the whole batch (one unit per array, by design).
+
+    Parameters
+    ----------
+    fun : callable
+        The function to vectorise; it may accept and return quantities.
+    **kwargs
+        Forwarded to :func:`jax.vmap` (``in_axes``, ``out_axes``, ...).
+
+    Returns
+    -------
+    callable
+        The vectorised function.
+
+    Examples
+    --------
+    >>> import duq.jax
+    >>> import jax.numpy as jnp
+    >>> f = duq.jax.vmap(lambda q: q * q)
+    >>> str(f(duq.jax.Quantity(jnp.array([1.0, 2.0]), "m")).unit)
+    'm²'
+    """
+    return jax.vmap(fun, **kwargs)

--- a/src/duq/jax/numpy.py
+++ b/src/duq/jax/numpy.py
@@ -1,0 +1,39 @@
+"""Unit-aware mirror of :mod:`jax.numpy` (quaxified on first access).
+
+Every function looked up on this module is ``quax.quaxify(jax.numpy.<name>)``,
+memoised, so :class:`duq.jax.Quantity` operands dispatch through the duq
+primitive rules while plain arrays behave exactly as in :mod:`jax.numpy`.
+Non-callable attributes (``pi``, ``inf``, dtypes, ...) are passed through
+unchanged.
+
+Examples
+--------
+>>> import duq.jax
+>>> import duq.jax.numpy as djnp
+>>> q = duq.jax.Quantity([1.0, 4.0], "m^2")
+>>> str(djnp.sqrt(q).unit)
+'m'
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+import quax
+
+__all__ = ()  # populated dynamically; see __getattr__/__dir__
+
+
+def __getattr__(name: str) -> Any:
+    """Return the quaxified ``jax.numpy`` attribute (memoised in the module)."""
+    attribute = getattr(jnp, name)  # AttributeError propagates with jnp's message
+    if callable(attribute) and not isinstance(attribute, type):
+        attribute = quax.quaxify(attribute)
+    globals()[name] = attribute  # memoise: next access skips __getattr__
+    return attribute
+
+
+def __dir__() -> list[str]:
+    """List the mirrored ``jax.numpy`` namespace."""
+    return sorted(set(globals()) | set(dir(jnp)))

--- a/src/duq/jax/numpy.py
+++ b/src/duq/jax/numpy.py
@@ -17,19 +17,95 @@ Examples
 
 from __future__ import annotations
 
+from types import ModuleType
 from typing import Any
 
 import jax.numpy as jnp
 import quax
 
+from duq._errors import DimensionalityError
+
+from ._quantity import Quantity
+
 __all__ = ()  # populated dynamically; see __getattr__/__dir__
+
+
+def _make_angle_convert(name: str, out_unit: str) -> Any:
+    """Build a unit-aware ``deg2rad``-family function (NumPy layer parity).
+
+    ``jax.numpy.deg2rad`` lowers to a bare multiplication, which would leave
+    the *label* of an angle quantity unchanged while rescaling its magnitude;
+    these curated overrides instead require a dimensionless operand (the raw
+    magnitude is passed through, exactly like the NumPy layer) and relabel
+    the result with the output angle unit.
+    """
+    jnp_func = getattr(jnp, name)
+
+    def convert(x: Any) -> Any:
+        if isinstance(x, Quantity):
+            if not x.unit.is_dimensionless:
+                raise DimensionalityError(
+                    f"expected a dimensionless operand, got dimension {x.unit.dimension}"
+                )
+            return Quantity(jnp_func(x.magnitude), x.unit.registry.unit(out_unit))
+        return jnp_func(x)
+
+    convert.__name__ = name
+    convert.__qualname__ = name
+    return convert
+
+
+#: Functions whose jax.numpy implementation is unit-unsafe at the primitive
+#: level and therefore gets a curated, unit-aware override.
+_OVERRIDES: dict[str, Any] = {
+    "deg2rad": _make_angle_convert("deg2rad", "rad"),
+    "radians": _make_angle_convert("radians", "rad"),
+    "rad2deg": _make_angle_convert("rad2deg", "deg"),
+    "degrees": _make_angle_convert("degrees", "deg"),
+}
+
+
+class _QuaxifiedModule:
+    """A quaxified view of a ``jax.numpy`` submodule (``linalg``, ``fft``, ...)."""
+
+    __slots__ = ("_cache", "_module")
+
+    def __init__(self, module: Any) -> None:
+        self._module = module
+        self._cache: dict[str, Any] = {}
+
+    def __getattr__(self, name: str) -> Any:
+        cached = self._cache.get(name)
+        if cached is not None:
+            return cached
+        attribute = getattr(self._module, name)
+        attribute = _wrap(attribute)
+        self._cache[name] = attribute
+        return attribute
+
+    def __dir__(self) -> list[str]:
+        return sorted(set(self._cache) | set(dir(self._module)))
+
+    def __repr__(self) -> str:
+        return f"<duq.jax quaxified view of {self._module.__name__!r}>"
+
+
+def _wrap(attribute: Any) -> Any:
+    """Quaxify a callable, proxy a module, and pass anything else through."""
+    if isinstance(attribute, ModuleType):
+        return _QuaxifiedModule(attribute)
+    if callable(attribute) and not isinstance(attribute, type):
+        return quax.quaxify(attribute)
+    return attribute
 
 
 def __getattr__(name: str) -> Any:
     """Return the quaxified ``jax.numpy`` attribute (memoised in the module)."""
-    attribute = getattr(jnp, name)  # AttributeError propagates with jnp's message
-    if callable(attribute) and not isinstance(attribute, type):
-        attribute = quax.quaxify(attribute)
+    override = _OVERRIDES.get(name)
+    if override is not None:
+        globals()[name] = override
+        return override
+    attribute = _wrap(getattr(jnp, name))  # AttributeError keeps jnp's message
     globals()[name] = attribute  # memoise: next access skips __getattr__
     return attribute
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Suite-wide collection config: skip the JAX tests when JAX is absent."""
+
+from __future__ import annotations
+
+import importlib.util
+
+collect_ignore: list[str] = []
+if importlib.util.find_spec("jax") is None:
+    collect_ignore.append("jax")

--- a/tests/jax/__init__.py
+++ b/tests/jax/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``duq.jax`` back-end (quax primitive interception)."""

--- a/tests/jax/conftest.py
+++ b/tests/jax/conftest.py
@@ -1,0 +1,7 @@
+"""JAX test configuration: enable float64 for parity with the NumPy layer."""
+
+from __future__ import annotations
+
+import jax
+
+jax.config.update("jax_enable_x64", True)  # type: ignore[no-untyped-call]

--- a/tests/jax/test_conformance.py
+++ b/tests/jax/test_conformance.py
@@ -1,0 +1,217 @@
+"""Shared conformance: the JAX layer must match the NumPy layer op-for-op.
+
+Each case runs the same operation twice -- ``numpy.<f>`` on core
+``duq.Quantity`` arrays and ``duq.jax.numpy.<f>`` on ``duq.jax.Quantity``
+arrays -- and asserts identical magnitudes (allclose) and identical units
+(or a plain, unit-free array on both sides).
+"""
+
+# The dispatch under test is deliberately dynamic; see tests/numpy/test_ufuncs.py.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, operator, index"
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import duq
+import duq.jax
+import duq.jax.numpy as djnp
+
+P = [1.0, 2.0, 3.0]
+Q2 = [2.0, 5.0, 7.0]
+R = [0.25, 0.5, 0.75]
+COND = [True, False, True]
+
+# Each case: op name -> (function name, [(values, unit-or-None), ...], kwargs).
+# A unit of None marks a plain (unit-free) operand.
+Case = tuple[str, list[tuple[object, str | None]], dict[str, object]]
+_CASES: dict[str, Case] = {
+    # multiplicative
+    "multiply": ("multiply", [(P, "m"), (Q2, "s")], {}),
+    "divide": ("divide", [(P, "m"), (Q2, "s")], {}),
+    "true_divide": ("true_divide", [(P, "m"), (Q2, "s")], {}),
+    "floor_divide": ("floor_divide", [(Q2, "m"), (P, "m")], {}),
+    "reciprocal": ("reciprocal", [(P, "m")], {}),
+    # additive / same dimension (right operand converted)
+    "add": ("add", [(P, "m"), (Q2, "m")], {}),
+    "add_convert": ("add", [(P, "m"), ([200.0, 500.0, 700.0], "cm")], {}),
+    "subtract": ("subtract", [(Q2, "m"), (P, "m")], {}),
+    "maximum": ("maximum", [(P, "m"), (Q2, "m")], {}),
+    "minimum": ("minimum", [(P, "m"), (Q2, "m")], {}),
+    "fmax": ("fmax", [(P, "m"), (Q2, "m")], {}),
+    "fmin": ("fmin", [(P, "m"), (Q2, "m")], {}),
+    "remainder": ("remainder", [(Q2, "m"), (P, "m")], {}),
+    "mod": ("mod", [(Q2, "m"), (P, "m")], {}),
+    "fmod": ("fmod", [(Q2, "m"), (P, "m")], {}),
+    "hypot": ("hypot", [([3.0], "m"), ([4.0], "m")], {}),
+    "copysign": ("copysign", [(P, "m"), ([-1.0, 1.0, -1.0], "m")], {}),
+    "nextafter": ("nextafter", [(P, "m"), (Q2, "m")], {}),
+    # powers
+    "power": ("power", [(P, "m"), (2, None)], {}),
+    "float_power_like": ("power", [(P, "m"), (2.0, None)], {}),
+    "sqrt": ("sqrt", [([1.0, 4.0, 9.0], "m^2")], {}),
+    "cbrt": ("cbrt", [([1.0, 8.0, 27.0], "m^3")], {}),
+    "square": ("square", [(P, "m")], {}),
+    # unary preserving
+    "negative": ("negative", [(P, "m")], {}),
+    "positive": ("positive", [(P, "m")], {}),
+    "absolute": ("absolute", [([-1.0, 2.0, -3.0], "m")], {}),
+    "fabs": ("fabs", [([-1.0, 2.0, -3.0], "m")], {}),
+    "floor": ("floor", [([1.7, -1.2], "m")], {}),
+    "ceil": ("ceil", [([1.2, -1.7], "m")], {}),
+    "trunc": ("trunc", [([1.7, -1.2], "m")], {}),
+    "rint": ("rint", [([1.5, 2.5], "m")], {}),
+    "round": ("round", [([1.4, 2.6], "m")], {}),
+    "conjugate": ("conjugate", [(P, "m")], {}),
+    "real": ("real", [([1.0 + 2.0j, 3.0 - 1.0j], "m")], {}),
+    "imag": ("imag", [([1.0 + 2.0j, 3.0 - 1.0j], "m")], {}),
+    # plain out
+    "sign": ("sign", [([-2.0, 0.0, 3.0], "m")], {}),
+    "isfinite": ("isfinite", [([1.0, np.inf, np.nan], "m")], {}),
+    "isnan": ("isnan", [([1.0, np.nan, 3.0], "m")], {}),
+    "isinf": ("isinf", [([1.0, np.inf, 3.0], "m")], {}),
+    # dimensionless in / out
+    "exp": ("exp", [(R, "1")], {}),
+    "exp_percent": ("exp", [([50.0], "%")], {}),
+    "exp2": ("exp2", [(R, "1")], {}),
+    "expm1": ("expm1", [(R, "1")], {}),
+    "log": ("log", [(P, "1")], {}),
+    "log2": ("log2", [(P, "1")], {}),
+    "log10": ("log10", [(P, "1")], {}),
+    "log1p": ("log1p", [(R, "1")], {}),
+    "sinh": ("sinh", [(R, "1")], {}),
+    "cosh": ("cosh", [(R, "1")], {}),
+    "tanh": ("tanh", [(R, "1")], {}),
+    "arcsinh": ("arcsinh", [(R, "1")], {}),
+    "arccosh": ("arccosh", [(P, "1")], {}),
+    "arctanh": ("arctanh", [(R, "1")], {}),
+    "logaddexp": ("logaddexp", [(R, "1"), (P, "1")], {}),
+    # angle in
+    "sin_rad": ("sin", [([0.0, np.pi / 2], "rad")], {}),
+    "cos_deg": ("cos", [([0.0, 180.0], "deg")], {}),
+    "tan_rad": ("tan", [(R, "rad")], {}),
+    # inverse trig
+    "arcsin": ("arcsin", [(R, "1")], {}),
+    "arccos": ("arccos", [(R, "1")], {}),
+    "arctan": ("arctan", [(P, "1")], {}),
+    "arctan2": ("arctan2", [(P, "m"), (Q2, "m")], {}),
+    # angle conversion (curated overrides in duq.jax.numpy)
+    "deg2rad": ("deg2rad", [([90.0, 180.0], "deg")], {}),
+    "radians": ("radians", [([90.0], "deg")], {}),
+    "rad2deg": ("rad2deg", [([np.pi], "rad")], {}),
+    "degrees": ("degrees", [([np.pi], "rad")], {}),
+    # joining / selection
+    "concatenate": ("concatenate", [([(P, "m"), ([100.0], "cm")], "SEQ")], {}),
+    "stack": ("stack", [([(P, "m"), (Q2, "m")], "SEQ")], {}),
+    "where": ("where", [(COND, None), (P, "m"), ([100.0, 200.0, 300.0], "cm")], {}),
+    "clip": ("clip", [(P, "m"), (150.0, "cm"), (2.5, "m")], {}),
+    "take": ("take", [(P, "m"), ([0, 2], None)], {}),
+    # reductions
+    "sum": ("sum", [(P, "m")], {}),
+    "nansum": ("nansum", [([1.0, np.nan, 3.0], "m")], {}),
+    "mean": ("mean", [(P, "m")], {}),
+    "nanmean": ("nanmean", [([1.0, np.nan, 3.0], "m")], {}),
+    "std": ("std", [(P, "m")], {}),
+    "var": ("var", [(P, "m")], {}),
+    "min": ("min", [(P, "m")], {}),
+    "max": ("max", [(P, "m")], {}),
+    "ptp": ("ptp", [(P, "m")], {}),
+    "median": ("median", [(P, "m")], {}),
+    "quantile": ("quantile", [(P, "m"), (0.5, None)], {}),
+    "cumsum": ("cumsum", [(P, "m")], {}),
+    "argmin": ("argmin", [(Q2, "m")], {}),
+    "argmax": ("argmax", [(Q2, "m")], {}),
+    # sorting / search
+    "sort": ("sort", [([3.0, 1.0, 2.0], "m")], {}),
+    "argsort": ("argsort", [([3.0, 1.0, 2.0], "m")], {}),
+    "searchsorted": ("searchsorted", [(P, "m"), (250.0, "cm")], {}),
+    # linalg-ish products
+    "dot": ("dot", [(P, "m"), (Q2, "s")], {}),
+    "inner": ("inner", [(P, "m"), (Q2, "s")], {}),
+    "outer": ("outer", [(P, "m"), (Q2, "s")], {}),
+    "matmul": ("matmul", [(P, "m"), (Q2, "s")], {}),
+    "einsum": ("einsum", [("i,i->", None), (P, "m"), (Q2, "s")], {}),
+    # shape / layout
+    "reshape": ("reshape", [(P, "m"), ((3, 1), None)], {}),
+    "ravel": ("ravel", [(P, "m")], {}),
+    "transpose": ("transpose", [(P, "m")], {}),
+    "squeeze": ("squeeze", [([[1.0], [2.0]], "m")], {}),
+    "flip": ("flip", [(P, "m")], {}),
+    "roll": ("roll", [(P, "m"), (1, None)], {}),
+    "repeat": ("repeat", [(P, "m"), (2, None)], {}),
+    "tile": ("tile", [(P, "m"), (2, None)], {}),
+    "broadcast_to": ("broadcast_to", [(P, "m"), ((2, 3), None)], {}),
+    "expand_dims": ("expand_dims", [(P, "m"), (0, None)], {}),
+    "atleast_1d": ("atleast_1d", [(P, "m")], {}),
+    "atleast_2d": ("atleast_2d", [(P, "m")], {}),
+    "diff": ("diff", [(Q2, "m")], {}),
+    "pad": ("pad", [(P, "m"), (1, None)], {}),
+    "diagonal": ("diagonal", [([[1.0, 2.0], [3.0, 4.0]], "m")], {}),
+    "trace_fn": ("trace", [([[1.0, 2.0], [3.0, 4.0]], "m")], {}),
+    "gradient": ("gradient", [(Q2, "m")], {}),
+}
+
+
+def _build_numpy(values: object, unit: str | None) -> object:
+    if unit == "SEQ":
+        return [_build_numpy(v, u) for v, u in values]
+    if unit is None:
+        return np.asarray(values) if isinstance(values, list) else values
+    return duq.Quantity(np.asarray(values), unit)
+
+
+def _build_jax(values: object, unit: str | None) -> object:
+    if unit == "SEQ":
+        return [_build_jax(v, u) for v, u in values]
+    if unit is None:
+        return jnp.asarray(values) if isinstance(values, list) else values
+    return duq.jax.Quantity(values, unit)
+
+
+@pytest.mark.parametrize("name", list(_CASES))
+def test_conformance_with_numpy_layer(name: str) -> None:
+    fname, arg_specs, kwargs = _CASES[name]
+    np_args = [_build_numpy(v, u) for v, u in arg_specs]
+    jax_args = [_build_jax(v, u) for v, u in arg_specs]
+    np_result = getattr(np, fname)(*np_args, **kwargs)
+    jax_result = getattr(djnp, fname)(*jax_args, **kwargs)
+
+    if isinstance(np_result, list):  # np.gradient returns a list for >1 axis
+        np_result = np_result[0] if len(np_result) == 1 else np_result
+    if isinstance(np_result, duq.Quantity):
+        assert isinstance(jax_result, duq.jax.Quantity), f"{name}: jax result lost its unit"
+        assert jax_result.unit == np_result.unit, (
+            f"{name}: unit mismatch {jax_result.unit} != {np_result.unit}"
+        )
+        np.testing.assert_allclose(
+            np.asarray(jax_result.value), np.asarray(np_result.value), err_msg=name
+        )
+    else:
+        assert not isinstance(jax_result, duq.jax.Quantity), (
+            f"{name}: jax result must be plain (numpy layer returned plain)"
+        )
+        np.testing.assert_allclose(np.asarray(jax_result), np.asarray(np_result), err_msg=name)
+
+
+def test_reduce_prod_unit_power() -> None:
+    # The JAX layer intentionally exceeds the NumPy layer here: reduction
+    # shapes are static under tracing, so prod's output unit is well-defined.
+    result = djnp.prod(duq.jax.Quantity([2.0, 3.0, 4.0], "m"))
+    assert result.unit == duq.unit("m^3")
+    np.testing.assert_allclose(float(result.value), 24.0)
+    matrix = djnp.prod(
+        duq.jax.Quantity([[2.0, 3.0], [4.0, 5.0]], "s"),
+        axis=0,
+    )
+    assert matrix.unit == duq.unit("s^2")
+
+
+def test_var_of_2d_along_axis_units() -> None:
+    a = duq.jax.Quantity([[1.0, 2.0], [3.0, 5.0]], "m")
+    result = djnp.var(a, axis=0)
+    assert result.unit == duq.unit("m^2")
+    np_ref = np.var(np.array([[1.0, 2.0], [3.0, 5.0]]), axis=0)
+    np.testing.assert_allclose(np.asarray(result.value), np_ref)

--- a/tests/jax/test_guards.py
+++ b/tests/jax/test_guards.py
@@ -1,0 +1,165 @@
+"""Fail-loud guards: uncovered primitives, dimension mismatches, affine policy."""
+
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, operator"
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import quax
+
+import duq
+import duq.jax
+import duq.jax.numpy as djnp
+from duq.jax import Quantity
+
+V = [1.0, 2.0, 3.0]
+
+
+def test_uncovered_primitive_fails_loud_naming_it() -> None:
+    spd = Quantity(jnp.eye(2) + 1.0, "m")
+    with pytest.raises(duq.UnsupportedOperationError, match="cholesky"):
+        djnp.linalg.cholesky(spd)
+
+
+def test_materialise_refuses() -> None:
+    with pytest.raises(duq.UnsupportedOperationError, match="materialise"):
+        Quantity(V, "m").materialise()
+
+
+def test_incompatible_dimensions_raise() -> None:
+    a, b = Quantity(V, "m"), Quantity(V, "s")
+    with pytest.raises(duq.DimensionalityError):
+        _ = a + b
+    with pytest.raises(duq.DimensionalityError):
+        djnp.add(a, b)
+    with pytest.raises(duq.DimensionalityError):
+        djnp.concatenate([a, b])
+    with pytest.raises(duq.DimensionalityError):
+        djnp.maximum(a, b)
+
+
+def test_bare_operand_with_dimensional_array_rejected() -> None:
+    a = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError):
+        _ = a + 2.0
+    with pytest.raises(duq.DimensionalityError):
+        _ = a + jnp.asarray(V)
+    with pytest.raises(duq.DimensionalityError):
+        djnp.maximum(a, 1.0)
+
+
+def test_dimensionless_functions_require_dimensionless() -> None:
+    a = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError):
+        djnp.exp(a)
+    with pytest.raises(duq.DimensionalityError):
+        djnp.sin(a)
+    with pytest.raises(duq.DimensionalityError):
+        djnp.arcsin(a)
+    with pytest.raises(duq.DimensionalityError):
+        djnp.deg2rad(a)
+
+
+def test_ordering_against_bare_nonzero_raises_but_zero_passes() -> None:
+    a = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError):
+        _ = a < 1.0
+    # 0/±inf/nan are scale-invariant: comparisons against them are meaningful
+    # in any linear unit (jnp compositions rely on this).
+    np.testing.assert_array_equal(np.asarray(a > 0.0), [True, True, True])
+    np.testing.assert_array_equal(np.asarray(a < np.inf), [True, True, True])
+    eq_zero = Quantity([0.0, 1.0], "m") == 0.0
+    np.testing.assert_array_equal(np.asarray(eq_zero), [True, False])
+
+
+def test_zero_comparison_on_affine_still_rejected() -> None:
+    celsius = Quantity([0.0], "degC")
+    with pytest.raises(duq.DimensionalityError):
+        _ = celsius < 0.0
+
+
+def test_traced_pow_exponent_on_dimensional_base_raises() -> None:
+    def f(base: Quantity, exponent: jax.Array) -> Quantity:
+        return base**exponent
+
+    with pytest.raises(duq.UnsupportedOperationError, match="traced"):
+        duq.jax.jit(f)(Quantity(2.0, "m"), jnp.asarray(2.0))
+    # ... but a scale-1 dimensionless base accepts a traced exponent
+    result = duq.jax.jit(f)(Quantity(2.0, "1"), jnp.asarray(3.0))
+    np.testing.assert_allclose(float(result.value), 8.0)
+    assert result.unit == duq.unit("1")
+
+
+def test_nonuniform_array_exponent_rejected() -> None:
+    with pytest.raises(duq.UnsupportedOperationError, match="exponent"):
+        djnp.power(Quantity(V, "m"), jnp.array([1.0, 2.0, 3.0]))
+    uniform = djnp.power(Quantity(V, "m"), jnp.array([2.0, 2.0, 2.0]))
+    assert uniform.unit == duq.unit("m^2")
+
+
+def test_quantity_exponent_must_be_dimensionless() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        djnp.power(Quantity(V, "m"), Quantity(2.0, "s"))
+    result = djnp.power(Quantity(V, "m"), Quantity(200.0, "%"))
+    assert result.unit == duq.unit("m^2")
+
+
+def test_cumprod_rejected_for_dimensional() -> None:
+    with pytest.raises(duq.UnsupportedOperationError, match="cumprod"):
+        djnp.cumprod(Quantity(V, "m"))
+    ok = djnp.cumprod(Quantity(V, "1"))
+    np.testing.assert_allclose(np.asarray(ok.value), [1.0, 2.0, 6.0])
+
+
+def test_affine_policy_matches_numpy_layer() -> None:
+    celsius = Quantity([0.0, 100.0], "degC")
+    with pytest.raises(duq.AffineUnitError):
+        _ = celsius + celsius
+    with pytest.raises(duq.AffineUnitError):
+        djnp.multiply(celsius, 2.0)
+    with pytest.raises(duq.AffineUnitError):
+        _ = -celsius
+    with pytest.raises(duq.AffineUnitError):
+        abs(celsius)
+    diff = celsius - Quantity([0.0, 50.0], "degC")
+    assert diff.unit == duq.unit("K")
+    np.testing.assert_allclose(np.asarray(diff.value), [0.0, 50.0])
+    with pytest.raises(duq.AffineUnitError):
+        djnp.dot(celsius, celsius)
+
+
+def test_affine_plus_delta_matches_core() -> None:
+    celsius = Quantity([20.0], "degC")
+    nudged = celsius + Quantity([5.0], "K")
+    assert nudged.unit == duq.unit("degC")
+    np.testing.assert_allclose(np.asarray(nudged.value), [25.0])
+    core = duq.Quantity(20.0, "degC") + duq.Quantity(5.0, "K")
+    np.testing.assert_allclose(float(core.value), 25.0)
+
+
+def test_relative_plus_affine_raises() -> None:
+    with pytest.raises(duq.AffineUnitError):
+        _ = Quantity([5.0], "K") + Quantity([20.0], "degC")
+
+
+def test_scatter_add_with_incompatible_updates_raises() -> None:
+    a = Quantity(V, "m")
+    with pytest.raises(duq.DimensionalityError):
+        a.at[0].add(Quantity(1.0, "s"))
+
+
+def test_quaxify_grad_scalar_check_sharp_edge_documented() -> None:
+    # quax's known sharp edge (quax#5): quaxify(jax.grad(f)) breaks when f
+    # returns a Quantity built from internally-created quantities, because the
+    # nested trace levels split the unit bookkeeping.  duq.jax.grad is the
+    # supported route; this test pins the failure mode so a future quax fix
+    # is noticed.
+    def kinetic(v: object) -> object:
+        return 0.5 * Quantity(2.0, "kg") * v * v
+
+    with pytest.raises(TypeError, match="scalar"):
+        quax.quaxify(jax.grad(kinetic))(Quantity(3.0, "m/s"))

--- a/tests/jax/test_meta_jax.py
+++ b/tests/jax/test_meta_jax.py
@@ -1,0 +1,60 @@
+"""Meta tests for the JAX layer: dependency pins and coverage-doc sync."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import equinox
+import quax
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+import duq.jax
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _jax_extra_requirements() -> dict[str, Requirement]:
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    requirements = [
+        Requirement(spec) for spec in pyproject["project"]["optional-dependencies"]["jax"]
+    ]
+    return {requirement.name: requirement for requirement in requirements}
+
+
+def test_installed_quax_satisfies_the_pyproject_pin() -> None:
+    requirements = _jax_extra_requirements()
+    assert "quax" in requirements, "the jax extra must pin quax"
+    specifier = requirements["quax"].specifier
+    assert specifier.contains(Version(quax.__version__)), (
+        f"installed quax {quax.__version__} violates the pyproject pin {specifier}"
+    )
+    # the pin must carry an upper bound (single-maintainer risk, design doc)
+    assert any(spec.operator in ("<", "<=", "==", "~=") for spec in specifier), (
+        "quax must be pinned with an upper bound"
+    )
+
+
+def test_installed_equinox_satisfies_the_pyproject_pin() -> None:
+    requirements = _jax_extra_requirements()
+    assert "equinox" in requirements
+    assert requirements["equinox"].specifier.contains(Version(equinox.__version__))
+
+
+def test_primitive_coverage_is_nonempty_and_sorted() -> None:
+    names = [name for name, _ in duq.jax.PRIMITIVE_COVERAGE]
+    assert len(names) >= 60
+    assert names == sorted(names)
+    assert len(set(names)) == len(names)
+
+
+def test_coverage_doc_lists_every_registered_primitive() -> None:
+    doc = (_REPO_ROOT / "docs" / "dev" / "jax_coverage.md").read_text()
+    documented = set(re.findall(r"^\| `([a-z0-9_-]+)` +\|", doc, flags=re.MULTILINE))
+    registered = {name for name, _ in duq.jax.PRIMITIVE_COVERAGE}
+    missing = registered - documented
+    stale = documented - registered
+    assert not missing, f"primitives missing from docs/dev/jax_coverage.md: {sorted(missing)}"
+    assert not stale, f"stale primitives in docs/dev/jax_coverage.md: {sorted(stale)}"

--- a/tests/jax/test_namespace.py
+++ b/tests/jax/test_namespace.py
@@ -1,0 +1,62 @@
+"""The duq.jax.numpy quaxified namespace: memoisation, passthrough, errors."""
+
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, no-untyped-call"
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import duq
+import duq.jax
+import duq.jax.numpy as djnp
+
+
+def test_functions_are_quaxified_and_memoised() -> None:
+    first = djnp.sqrt
+    assert first is djnp.sqrt  # second access hits the memoised module global
+    result = first(duq.jax.Quantity([4.0], "m^2"))
+    assert result.unit == duq.unit("m")
+
+
+def test_plain_arrays_behave_like_jax_numpy() -> None:
+    np.testing.assert_allclose(np.asarray(djnp.sqrt(jnp.array([4.0]))), [2.0])
+    np.testing.assert_allclose(np.asarray(djnp.linspace(0.0, 1.0, 3)), np.linspace(0.0, 1.0, 3))
+
+
+def test_non_callables_pass_through() -> None:
+    assert djnp.pi == jnp.pi
+    assert djnp.float32 is jnp.float32  # a type: not wrapped
+
+
+def test_missing_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        _ = djnp.definitely_not_a_numpy_function
+
+
+def test_dir_lists_jnp_names() -> None:
+    listing = dir(djnp)
+    assert "sqrt" in listing
+    assert "concatenate" in listing
+
+
+def test_submodules_are_quaxified_proxies() -> None:
+    # jnp.linalg is proxied so its covered functions carry units...
+    result = djnp.linalg.norm(duq.jax.Quantity([3.0, 4.0], "m"))
+    assert result.unit == duq.unit("m")
+    np.testing.assert_allclose(float(result.value), 5.0)
+    assert "linalg" in repr(djnp.linalg)
+    assert "norm" in dir(djnp.linalg)
+    assert djnp.linalg.norm is djnp.linalg.norm  # memoised
+    # ...and plain arrays still behave like jax.numpy.linalg
+    np.testing.assert_allclose(float(djnp.linalg.norm(jnp.array([3.0, 4.0]))), 5.0)
+
+
+def test_angle_conversion_overrides_are_unit_aware() -> None:
+    q = duq.jax.Quantity([90.0], "deg")
+    result = djnp.deg2rad(q)
+    assert result.unit == duq.unit("rad")
+    np.testing.assert_allclose(np.asarray(result.value), [np.pi / 2])
+    # plain operands pass straight through to jax.numpy
+    np.testing.assert_allclose(float(djnp.rad2deg(np.pi)), 180.0)

--- a/tests/jax/test_quantity.py
+++ b/tests/jax/test_quantity.py
@@ -1,0 +1,311 @@
+"""duq.jax.Quantity: construction, conversion, operators and coercion."""
+
+# JAX's stubs cannot describe quax Value operands; the deliberately dynamic
+# dispatch these tests exercise trips the same false positives as the NumPy
+# conformance suite.
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, operator"
+
+from __future__ import annotations
+
+from decimal import Decimal
+from fractions import Fraction
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import duq
+import duq.jax
+from duq.jax import Quantity
+
+V = [1.0, 2.0, 3.0]
+
+
+def q(values: object = None, unit: str = "m") -> Quantity:
+    return Quantity(V if values is None else values, unit)
+
+
+# -- construction ---------------------------------------------------------------
+
+
+def test_construct_from_list_scalar_numpy_and_jax() -> None:
+    assert q().shape == (3,)
+    assert Quantity(2.0, "m").shape == ()
+    assert Quantity(np.array(V), "m").shape == (3,)
+    assert Quantity(jnp.array(V), "m").shape == (3,)
+    assert Quantity(2, "m").dtype == jnp.asarray(2).dtype
+
+
+def test_construct_fraction_and_decimal_coerce_to_float() -> None:
+    assert float(Quantity(Fraction(1, 2), "1").value) == 0.5
+    assert float(Quantity(Decimal("0.25"), "1").value) == 0.25
+
+
+def test_construct_with_unit_object_and_bad_unit_type() -> None:
+    assert Quantity(1.0, duq.unit("kJ/mol")).unit == duq.unit("kJ/mol")
+    with pytest.raises(TypeError, match="unit must be"):
+        Quantity(1.0, 42)
+
+
+def test_construct_rejects_core_quantity() -> None:
+    with pytest.raises(TypeError, match="from_core"):
+        Quantity(duq.Quantity(1.0, "m"), "m")
+
+
+def test_core_quantity_rejects_jax_magnitude() -> None:
+    with pytest.raises(TypeError, match=r"duq\.jax\.Quantity"):
+        duq.Quantity(jnp.array(V), "m")
+
+
+def test_from_core_and_to_core_roundtrip() -> None:
+    core = duq.Quantity(np.array(V), "kJ/mol")
+    jq = Quantity.from_core(core)
+    assert jq.unit == core.unit
+    back = jq.to_core()
+    assert isinstance(back, duq.Quantity)
+    assert back.is_array
+    np.testing.assert_allclose(np.asarray(back.value), V)
+
+
+def test_properties() -> None:
+    a = q()
+    assert a.dimension == duq.dimension("length")
+    assert a.value is a.magnitude
+    assert a.ndim == 1
+    assert a.size == 3
+    assert a.shape == (3,)
+
+
+# -- conversion -------------------------------------------------------------------
+
+
+def test_to_and_value_in() -> None:
+    a = Quantity(1.0, "km")
+    np.testing.assert_allclose(float(a.to("m").value), 1000.0)
+    np.testing.assert_allclose(float(a.value_in("cm")), 100_000.0)
+    assert a.to("m").unit == duq.unit("m")
+
+
+def test_to_same_scale_is_noop_relabel() -> None:
+    a = Quantity(V, "J")
+    b = a.to("kg.m^2/s^2")
+    assert b.unit == duq.unit("J")
+    np.testing.assert_allclose(np.asarray(b.value), V)
+
+
+def test_to_affine_celsius() -> None:
+    c = Quantity([0.0, 100.0], "degC")
+    np.testing.assert_allclose(np.asarray(c.to("K").value), [273.15, 373.15])
+    back = c.to("K").to("degC")
+    np.testing.assert_allclose(np.asarray(back.value), [0.0, 100.0], atol=1e-12)
+
+
+def test_to_incompatible_raises() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        q().to("s")
+    with pytest.raises(ValueError, match="equivalence"):
+        q().to("m", equivalence="nope")
+
+
+def test_to_molar_equivalence() -> None:
+    a = Quantity(1.0, "kJ/mol")
+    j = a.to("J", equivalence="molar")
+    assert j.unit == duq.unit("J")
+    core = duq.Quantity(1.0, "kJ/mol").to("J", equivalence="molar")
+    np.testing.assert_allclose(float(j.value), float(core.value))
+    with pytest.raises(duq.DimensionalityError):
+        a.to("m", equivalence="molar")
+    with pytest.raises(duq.AffineUnitError):
+        Quantity(1.0, "degC").to("K", equivalence="molar")
+
+
+# -- scalar coercion ----------------------------------------------------------------
+
+
+def test_dimensionless_coercion_matches_core_policy() -> None:
+    assert float(Quantity(50.0, "%")) == pytest.approx(0.5)
+    assert int(Quantity(200.0, "%")) == 2
+    assert complex(Quantity(50.0, "%")) == pytest.approx(0.5 + 0j)
+    assert bool(Quantity(50.0, "%")) is True
+    assert bool(Quantity(0.0, "1")) is False
+    assert float(Quantity(1.5, "rad")) == pytest.approx(1.5)
+
+
+def test_dimensional_coercion_fails_loud() -> None:
+    a = Quantity(2.0, "m")
+    for coerce in (float, int, complex, bool):
+        with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+            coerce(a)
+
+
+def test_array_conversion_fails_loud() -> None:
+    with pytest.raises(duq.UnsupportedOperationError, match="ustrip"):
+        np.asarray(q())
+    with pytest.raises(duq.UnsupportedOperationError):
+        q().__array__()
+
+
+# -- operators -------------------------------------------------------------------------
+
+
+def test_add_sub_convert_units() -> None:
+    a = q()
+    b = Quantity([100.0, 200.0, 300.0], "cm")
+    np.testing.assert_allclose(np.asarray((a + b).value), [2.0, 4.0, 6.0])
+    assert (a + b).unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray((a - b).value), [0.0, 0.0, 0.0])
+
+
+def test_reflected_add_sub_with_dimensionless() -> None:
+    a = Quantity(3.0, "1")
+    assert float((2.0 + a).value) == 5.0
+    assert float((2.0 - a).value) == -1.0
+
+
+def test_mul_div_operators() -> None:
+    a, b = q(), Quantity([2.0, 5.0, 7.0], "s")
+    assert (a * b).unit == duq.unit("m*s")
+    assert (a / b).unit == duq.unit("m/s")
+    assert (2.0 * a).unit == duq.unit("m")
+    assert (a / 2.0).unit == duq.unit("m")
+    assert (1.0 / a).unit == duq.unit("m^-1")
+
+
+def test_floordiv_and_mod_operators() -> None:
+    a = Quantity([7.0], "m")
+    b = Quantity([300.0], "cm")
+    np.testing.assert_allclose(np.asarray((a % b).value), [1.0])
+    assert (a % b).unit == duq.unit("m")
+    result = Quantity([7.0], "1") // Quantity([3.0], "1")
+    np.testing.assert_allclose(np.asarray(result.value), [2.0])
+    assert float((8.0 % Quantity(3.0, "1")).value) == 2.0
+    assert float((8.0 // Quantity(3.0, "1")).value) == 2.0
+
+
+def test_pow_operator() -> None:
+    a = q()
+    assert (a**2).unit == duq.unit("m^2")
+    assert (a**0.5).unit == duq.unit("m") ** Fraction(1, 2)
+    np.testing.assert_allclose(np.asarray((a**2).value), np.array(V) ** 2)
+
+
+def test_matmul_operator() -> None:
+    a = Quantity(jnp.eye(3), "kg")
+    b = q()
+    assert (a @ b).unit == duq.unit("kg*m")
+    assert (np.asarray(np.eye(3)) @ b).unit == duq.unit("m")
+
+
+def test_unary_operators() -> None:
+    a = q()
+    np.testing.assert_allclose(np.asarray((-a).value), [-1.0, -2.0, -3.0])
+    assert (+a) is a
+    np.testing.assert_allclose(np.asarray(abs(-a).value), V)
+
+
+def test_comparison_operators_convert() -> None:
+    a = q()
+    b = Quantity([100.0, 200.0, 300.0], "cm")
+    assert bool(jnp.all(a == b))
+    assert not bool(jnp.any(a != b))
+    assert bool(jnp.all(a <= b))
+    assert bool(jnp.all(a >= b))
+    assert not bool(jnp.any(a < b))
+    assert not bool(jnp.any(a > b))
+
+
+def test_eq_on_incompatible_dims_matches_numpy_layer() -> None:
+    a, b = q(), Quantity(V, "s")
+    jax_eq = np.asarray(a == b)
+    jax_ne = np.asarray(a != b)
+    core_a = duq.Quantity(np.array(V), "m")
+    core_b = duq.Quantity(np.array(V), "s")
+    np.testing.assert_array_equal(jax_eq, np.asarray(core_a == core_b))
+    np.testing.assert_array_equal(jax_ne, np.asarray(core_a != core_b))
+    assert not jax_eq.any()
+    assert jax_ne.all()
+
+
+def test_order_compare_incompatible_raises() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        _ = q() < Quantity(V, "s")
+
+
+def test_operator_with_unsupported_type_returns_notimplemented() -> None:
+    with pytest.raises(TypeError):
+        _ = q() + "banana"
+
+
+def test_mixing_core_quantity_raises_with_guidance() -> None:
+    with pytest.raises(TypeError, match="from_core"):
+        _ = q() * duq.Quantity(2.0, "s")
+    with pytest.raises(TypeError, match="from_core"):
+        _ = duq.Quantity(2.0, "s") * q()
+
+
+def test_unhashable_like_ndarray() -> None:
+    with pytest.raises(TypeError, match="unhashable"):
+        hash(q())
+
+
+# -- array ergonomics ----------------------------------------------------------------------
+
+
+def test_getitem_len_and_at() -> None:
+    a = q()
+    assert float(a[0].value) == 1.0
+    assert a[0].unit == duq.unit("m")
+    assert len(a) == 3
+    with pytest.raises(TypeError, match="unsized"):
+        len(Quantity(1.0, "m"))
+    updated = a.at[0].set(Quantity(900.0, "cm"))
+    np.testing.assert_allclose(np.asarray(updated.value), [9.0, 2.0, 3.0])
+    added = a.at[0].add(Quantity(100.0, "cm"))
+    np.testing.assert_allclose(np.asarray(added.value), [2.0, 2.0, 3.0])
+    subtracted = a.at[0].subtract(Quantity(100.0, "cm"))
+    np.testing.assert_allclose(np.asarray(subtracted.value), [0.0, 2.0, 3.0])
+    clipped_lo = a.at[0].max(Quantity(250.0, "cm"))
+    np.testing.assert_allclose(np.asarray(clipped_lo.value), [2.5, 2.0, 3.0])
+    clipped_hi = a.at[2].min(Quantity(250.0, "cm"))
+    np.testing.assert_allclose(np.asarray(clipped_hi.value), [1.0, 2.0, 2.5])
+    got = a.at[1].get()
+    assert float(got.value) == 2.0
+    assert got.unit == duq.unit("m")
+
+
+def test_at_set_incompatible_raises() -> None:
+    with pytest.raises(duq.DimensionalityError):
+        q().at[0].set(Quantity(1.0, "s"))
+
+
+# -- rendering / pytree -----------------------------------------------------------------------
+
+
+def test_repr_and_str() -> None:
+    a = Quantity(2.0, "kJ/mol")
+    assert "Quantity(" in repr(a)
+    assert "kJ" in repr(a)
+    assert str(a).endswith("kJ·mol⁻¹")
+
+
+def test_pytree_flatten_keeps_unit_static() -> None:
+    a = q()
+    leaves, treedef = jax.tree_util.tree_flatten(a)
+    assert len(leaves) == 1
+    assert leaves[0].shape == (3,)
+    rebuilt = jax.tree_util.tree_unflatten(treedef, leaves)
+    assert rebuilt.unit == duq.unit("m")
+    other_treedef = jax.tree_util.tree_flatten(Quantity(V, "km"))[1]
+    assert treedef != other_treedef  # distinct units -> distinct treedefs (jit keys)
+
+
+def test_uconvert_ustrip_dispatch_on_jax_quantity() -> None:
+    a = Quantity(1.0, "m")
+    converted = duq.uconvert("cm", a)
+    assert isinstance(converted, Quantity)
+    assert converted.unit == duq.unit("cm")
+    stripped = duq.ustrip("cm", a)
+    assert isinstance(stripped, jax.Array)
+    np.testing.assert_allclose(float(stripped), 100.0)

--- a/tests/jax/test_transforms.py
+++ b/tests/jax/test_transforms.py
@@ -1,0 +1,227 @@
+"""jit / grad / vmap / scan / cond / while behaviour with unit-carrying arrays."""
+
+# mypy: disable-error-code="arg-type, call-overload, attr-defined, union-attr"
+# mypy: disable-error-code="type-var, return-value, no-untyped-call, operator, no-any-return"
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import quax
+
+import duq
+import duq.jax
+import duq.jax.numpy as djnp
+from duq.jax import Quantity
+
+
+def kinetic(v: Quantity) -> Quantity:
+    """Return the kinetic energy of a 2 kg mass (a quantity created inside)."""
+    return 0.5 * Quantity(2.0, "kg") * v * v
+
+
+# -- jit ---------------------------------------------------------------------------
+
+
+def test_jit_pytree_style_unit_correct() -> None:
+    result = jax.jit(lambda q: q * q)(Quantity([3.0], "m"))
+    assert isinstance(result, Quantity)
+    assert result.unit == duq.unit("m^2")
+    np.testing.assert_allclose(np.asarray(result.value), [9.0])
+
+
+def test_jit_wrapper_unit_correct() -> None:
+    result = duq.jax.jit(kinetic)(Quantity(3.0, "m/s"))
+    assert result.unit == duq.unit("kg") * duq.unit("m/s") ** 2
+    np.testing.assert_allclose(float(result.value), 9.0)
+
+
+def test_jit_retraces_per_unit_but_not_per_call() -> None:
+    traces = []
+
+    @duq.jax.jit
+    def f(q: Quantity) -> Quantity:
+        traces.append(q.unit)  # Python side effect: runs only when tracing
+        return q * q
+
+    a = jnp.array([1.0, 2.0])
+    f(Quantity(a, "m"))
+    f(Quantity(a * 2, "m"))  # same unit -> cached, no retrace
+    assert len(traces) == 1
+    result = f(Quantity(a, "km"))  # new unit -> retrace
+    assert len(traces) == 2
+    assert result.unit == duq.unit("km^2")
+    f(Quantity(a, "km"))
+    assert len(traces) == 2
+
+
+def test_jit_with_ustrip_hot_kernel_pattern() -> None:
+    @duq.jax.jit
+    def hot(mag: jax.Array) -> jax.Array:
+        return mag * 2.0
+
+    q = Quantity([1.0, 2.0], "km")
+    out = Quantity(hot(duq.ustrip("m", q)), "m")
+    np.testing.assert_allclose(np.asarray(out.value), [2000.0, 4000.0])
+
+
+# -- grad --------------------------------------------------------------------------
+
+
+def test_grad_unit_is_exactly_out_over_in() -> None:
+    g = duq.jax.grad(kinetic)(Quantity(3.0, "m/s"))
+    assert isinstance(g, Quantity)
+    assert g.unit == duq.unit("J") / duq.unit("m/s")
+    np.testing.assert_allclose(float(g.value), 6.0)  # d(1/2 m v^2)/dv = m v
+
+
+def test_grad_of_ustripped_scalar_returns_plain() -> None:
+    g = duq.jax.grad(lambda q: duq.ustrip("J", kinetic(q)))(Quantity(3.0, "m/s"))
+    assert not isinstance(g, Quantity)
+    np.testing.assert_allclose(float(g), 6.0)
+
+
+def test_grad_multiple_argnums() -> None:
+    def energy(m: Quantity, v: Quantity) -> Quantity:
+        return 0.5 * m * v * v
+
+    gm, gv = duq.jax.grad(energy, argnums=(0, 1))(Quantity(2.0, "kg"), Quantity(3.0, "m/s"))
+    assert gm.unit == duq.unit("J") / duq.unit("kg")
+    assert gv.unit == duq.unit("J") / duq.unit("m/s")
+    np.testing.assert_allclose(float(gm.value), 4.5)
+    np.testing.assert_allclose(float(gv.value), 6.0)
+
+
+def test_grad_through_unit_conversion() -> None:
+    g = duq.jax.grad(lambda q: (q * q).to("cm^2"))(Quantity(3.0, "m"))
+    assert g.unit == duq.unit("cm^2") / duq.unit("m")
+    np.testing.assert_allclose(float(g.value), 60_000.0)  # d(x^2 cm^2)/dx m
+
+
+def test_jacfwd_jacrev_and_hessian_smoke() -> None:
+    square = lambda q: q * q  # noqa: E731
+    x = Quantity(jnp.array([1.0, 2.0]), "m")
+    jf = duq.jax.jacfwd(square)(x)
+    assert isinstance(jf, Quantity)
+    assert jf.unit == duq.unit("m^2") / duq.unit("m")
+    np.testing.assert_allclose(np.asarray(jf.value), np.diag([2.0, 4.0]))
+    jr = duq.jax.jacrev(square)(x)
+    assert jr.unit == jf.unit
+    np.testing.assert_allclose(np.asarray(jr.value), np.asarray(jf.value))
+    h = duq.jax.hessian(kinetic)(Quantity(3.0, "m/s"))
+    assert h.unit == duq.unit("J") / duq.unit("m/s") ** 2
+    np.testing.assert_allclose(float(h.value), 2.0)  # d2(1/2 m v^2)/dv2 = m
+
+
+# -- vmap ---------------------------------------------------------------------------
+
+
+def test_vmap_over_magnitude_axis_unit_shared() -> None:
+    batched = duq.jax.vmap(kinetic)(Quantity(jnp.array([1.0, 2.0, 3.0]), "m/s"))
+    assert isinstance(batched, Quantity)
+    assert batched.unit == duq.unit("kg") * duq.unit("m/s") ** 2
+    np.testing.assert_allclose(np.asarray(batched.value), [1.0, 4.0, 9.0])
+
+
+def test_plain_jax_vmap_works_on_quantity_pytrees() -> None:
+    batched = jax.vmap(lambda q: q + q)(Quantity(jnp.array([1.0, 2.0]), "m"))
+    assert batched.unit == duq.unit("m")
+
+
+# -- control flow ---------------------------------------------------------------------
+
+
+def test_scan_carry_keeps_unit_across_steps() -> None:
+    def step(carry: Quantity, x: Quantity) -> tuple[Quantity, Quantity]:
+        new = carry + x
+        return new, new
+
+    xs = Quantity(jnp.array([1.0, 2.0, 3.0]), "m")
+    final, ys = jax.lax.scan(step, Quantity(0.0, "m"), xs)
+    assert final.unit == duq.unit("m")
+    assert ys.unit == duq.unit("m")
+    np.testing.assert_allclose(float(final.value), 6.0)
+    np.testing.assert_allclose(np.asarray(ys.value), [1.0, 3.0, 6.0])
+
+
+def test_scan_carry_converts_mixed_units_per_rule() -> None:
+    def step(carry: Quantity, x: Quantity) -> tuple[Quantity, Quantity]:
+        new = carry + x.to("m")
+        return new, new
+
+    xs = Quantity(jnp.array([100.0, 200.0]), "cm")
+    final, _ = jax.lax.scan(step, Quantity(0.0, "m"), xs)
+    np.testing.assert_allclose(float(final.value), 3.0)
+
+
+def test_while_loop_with_quantity_carry() -> None:
+    result = jax.lax.while_loop(
+        lambda c: c < Quantity(10.0, "m"),
+        lambda c: c * 2.0,
+        Quantity(1.0, "m"),
+    )
+    assert result.unit == duq.unit("m")
+    np.testing.assert_allclose(float(result.value), 16.0)
+
+
+def test_cond_with_consistent_units() -> None:
+    def branchy(pred: object, q: Quantity) -> Quantity:
+        return jax.lax.cond(pred, lambda x: x * 2.0, lambda x: x * 3.0, q)
+
+    a = Quantity(1.0, "m")
+    np.testing.assert_allclose(float(branchy(True, a).value), 2.0)
+    np.testing.assert_allclose(float(branchy(False, a).value), 3.0)
+    assert branchy(True, a).unit == duq.unit("m")
+
+
+def test_cond_with_different_units_raises_clearly() -> None:
+    with pytest.raises(TypeError, match="pytree"):
+        jax.lax.cond(True, lambda x: x.to("cm"), lambda x: x, Quantity(1.0, "m"))
+
+
+def test_where_converts_compatible_branch_units() -> None:
+    # jnp.where is the select_n route: branches converge to the first unit.
+    result = djnp.where(
+        jnp.array([True, False]),
+        Quantity([1.0, 2.0], "m"),
+        Quantity([300.0, 400.0], "cm"),
+    )
+    assert result.unit == duq.unit("m")
+    np.testing.assert_allclose(np.asarray(result.value), [1.0, 4.0])
+
+
+# -- affine °C under jit -----------------------------------------------------------------
+
+
+def test_celsius_to_kelvin_under_jit() -> None:
+    convert = duq.jax.jit(lambda q: q.to("K"))
+    result = convert(Quantity(jnp.array([0.0, 100.0]), "degC"))
+    assert result.unit == duq.unit("K")
+    np.testing.assert_allclose(np.asarray(result.value), [273.15, 373.15])
+
+
+def test_celsius_arithmetic_raises_at_trace_time() -> None:
+    celsius = Quantity(jnp.array([25.0]), "degC")
+    with pytest.raises(duq.AffineUnitError):
+        duq.jax.jit(lambda q: q + q)(celsius)
+    with pytest.raises(duq.AffineUnitError):
+        duq.jax.jit(lambda q: q * 2.0)(celsius)
+    diff = duq.jax.jit(lambda q: q - Quantity(jnp.array([20.0]), "degC"))(celsius)
+    assert diff.unit == duq.unit("K")  # degC - degC is a difference in kelvin
+    np.testing.assert_allclose(np.asarray(diff.value), [5.0])
+
+
+# -- quaxify interoperability -----------------------------------------------------------
+
+
+def test_raw_quaxify_style_with_arguments_only() -> None:
+    # The quaxed-style composition works when quantities enter as arguments.
+    def f(x: object, y: object) -> object:
+        return jnp.sqrt(x * x + y * y)
+
+    result = quax.quaxify(f)(Quantity(3.0, "m"), Quantity(400.0, "cm"))
+    assert isinstance(result, Quantity)
+    assert result.unit == duq.unit("m")
+    np.testing.assert_allclose(float(result.value), 5.0)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from fractions import Fraction
@@ -18,6 +19,42 @@ def test_import_does_not_import_numpy() -> None:
         "_ = q.to('J'); _ = duq.constants.k_B; _ = duq.unit('kg.m^2/s^2')\n"
         "assert 'numpy' not in sys.modules, 'numpy was imported by the core'\n"
         "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_import_does_not_import_jax() -> None:
+    code = (
+        "import sys, duq\n"
+        "q = duq.Quantity(2.0, 'kJ/mol') * duq.Quantity(3.0, 'mol')\n"
+        "_ = q.to('J'); _ = duq.unit('kg.m^2/s^2')\n"
+        "assert 'jax' not in sys.modules, 'jax was imported by the core'\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("jax") is not None,
+    reason="jax is installed; the ImportError path only exists without it",
+)
+def test_import_duq_jax_without_jax_raises_helpful_error() -> None:
+    code = (
+        "try:\n"
+        "    import duq.jax\n"
+        "except ImportError as exc:\n"
+        "    assert 'duq[jax]' in str(exc), str(exc)\n"
+        "    print('ok')\n"
+        "else:\n"
+        "    print('no error')\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", code], capture_output=True, text=True, check=False


### PR DESCRIPTION
PR 4 of the 5-PR overhaul (stacked on #4 `feat/numpy`). Adds the JAX back-end: `duq.jax.Quantity`, a quax `ArrayValue` whose magnitude is the traced pytree leaf and whose **unit is static metadata** — units are checked and propagated at trace time through per-primitive rules driven by the shared core `duq._rules` engine, and cost nothing at runtime.

## Architecture (per `design.md` §3.5 / research report §2)

- `magnitude: jax.Array` (leaf), `unit: duq.Unit = eqx.field(static=True)` → the unit is part of the treedef, hence part of `jit`'s cache key: same unit → cached, new unit → retrace (demonstrated by test).
- `materialise()` refuses; an overridden `Quantity.default` makes **every uncovered primitive fail loud naming the primitive** — units are never silently dropped.
- `import duq` never imports JAX (subprocess-asserted); `import duq.jax` without the extra raises `ImportError` with the `pip install 'duq[jax]'` hint (subprocess-asserted in the no-jax envs); the core `duq.Quantity` constructor rejects JAX arrays/tracers via a module-name sniff with a pointer to `duq.jax.Quantity` — still no jax import.
- `duq.uconvert`/`duq.ustrip` dispatch structurally on any quantity flavour via the new `duq.QuantityLike` protocol.
- `duq.jax.numpy`: lazily quaxified mirror of `jax.numpy` via module `__getattr__` (memoised), with proxied submodules (`linalg`, `fft`, …) and curated unit-aware `deg2rad`/`rad2deg`/`radians`/`degrees` overrides (the jnp originals lower to a bare `mul`, which would rescale without relabelling).
- Dependency policy: `jax = ["jax>=0.5", "quax>=0.3.6,<0.5", "equinox>=0.11"]` — quax pinned with an upper bound (single-maintainer risk, research report Risk #4) and isolated entirely behind `duq/jax/`. quax is not on conda-forge → pixi `jax` feature pulls it from PyPI.

## Primitive coverage — 93 primitives

Full generated table in `docs/dev/jax_coverage.md` (`docs/dev/generate_jax_coverage.py`; a test asserts doc ↔ registry sync). Summary:

| Family | Primitives | Rule |
|---|---|---|
| Additive | `add`, `sub` | same-dim, right→left conversion, full core affine (°C) policy incl. °C−°C→K |
| Same-dim | `max`, `min`, `rem`, `nextafter` | converted to the reference unit |
| Multiplicative | `mul`, `div`, `dot_general` | units multiply/divide; affine rejected |
| Powers | `pow`, `integer_pow`, `square`, `sqrt`, `rsqrt`, `cbrt` | `unit**y`; traced exponent only for scale-1 dimensionless base |
| Dimensionless-in | `exp`, `exp2`, `expm1`, `log`, `log1p`, `logistic`, `tanh`, `sinh`, `cosh`, `asinh`, `acosh`, `atanh`, `erf`, `erfc`, `erf_inv` | `%` rescaled at trace time; dimensionless out |
| Angle | `sin`, `cos`, `tan` (in), `asin`, `acos`, `atan`, `atan2` (rad out) | deg/rad scale-converted at trace time |
| Preserve (unary) | `neg`, `abs` (affine rejected), `floor`, `ceil`, `round`, `real`, `imag`, `conj` | unit preserved |
| Structure | `broadcast_in_dim`, `reshape`, `transpose`, `squeeze`, `rev`, `slice`, `copy`, `tile`, `convert_element_type`, `stop_gradient` | unit preserved |
| Reductions | `reduce_sum`/`max`/`min`, `cumsum`, `cummax`, `cummin` (preserve); `reduce_prod` → **`unit**n`** (static shapes); `cumprod` rejected for dimensional; `argmax`/`argmin`/`reduce_and`/`reduce_or` plain | |
| Comparisons | `eq`, `ne`, `lt`, `le`, `gt`, `ge` + `eq_to`/`lt_to`/`le_to` | converted; incompatible `eq`/`ne` → all-False/all-True (NumPy-layer parity); ordering raises |
| N-ary | `concatenate`, `stack`, `select_n`, `sort`, `split`, `pad` | converted to the reference unit |
| Indexing | `gather`, `dynamic_slice`, `dynamic_update_slice`, `scatter`, `scatter_add/sub/min/max` | updates converted; unit-aware `.at[…]` helper on the Quantity |
| Plain-out | `sign`, `is_finite`, `bitcast_convert_type` | |
| Control flow | `cond`/`while`/`scan`/`pjit` | handled by quax itself; tested with quantity carries/branches |

Everything else (lax.linalg decompositions, FFT, conv, …) fails loud naming the primitive.

**Plain-operand policy** (documented in `_primitives.py` and the coverage doc): arithmetic mirrors the NumPy layer exactly (bare operands only with dimensionless quantities). Two JAX-specific relaxations keep `jnp` compositions working, because they inject literals at the primitive level: (1) comparisons accept *concrete* scale-invariant literals (all `0`/`±inf`/`nan`) against any linear unit — this is what makes `trunc`, `remainder`, `floor_divide`, `isinf` work; (2) the structural combination primitives (`select_n`/`pad`/`dynamic_update_slice`/`scatter*`) let plain operands adopt the reference unit (unxt-parity) — required for `var`, `std`, `hypot`, `take`, `jnp.pad` under jit, where the literals are already traced.

## Transformation results (all tested)

| Transformation | Behaviour |
|---|---|
| `jax.jit` / `duq.jax.jit` | Quantities pass as pytrees; unit-correct outputs. Retrace-per-unit demonstrated with a trace-side-effect counter: m→1 trace, m again→no retrace, km→2nd trace, km again→no retrace |
| `duq.jax.grad` | **gradient unit == `unit_out / unit_in`, asserted exactly** (`d(½mv²)/dv` → `J/(m/s)`); works with quantities created *inside* the function; multi-`argnums`; `grad(lambda q: ustrip("J", kinetic(q)))`-style returns plain magnitudes |
| `duq.jax.jacfwd`/`jacrev` | Jacobian unit `unit_out/unit_in` via nested-quantity collapse |
| `duq.jax.hessian` | `unit_out/unit_in²`, asserted exactly |
| `jax.vmap` / `duq.jax.vmap` | batches the magnitude axis; unit shared across the batch |
| `lax.scan` | quantity carry keeps its unit across steps (incl. mixed-unit conversion in the body) |
| `lax.while_loop` | quantity carry + unit-aware condition |
| `lax.cond` | consistent-unit branches work; different-unit branches raise a clear `TypeError` (pytree mismatch); `jnp.where` converts compatible branch units per the `select_n` rule |
| affine °C | `.to("K")` works under jit (traced shift); °C arithmetic raises `AffineUnitError` at trace time |

## Verification

| Gate | Result |
|---|---|
| `pixi run -e lint lint` | ✅ All checks passed |
| `pixi run -e lint fmt-check` | ✅ 53 files already formatted |
| `pixi run -e type typecheck` (mypy --strict, now incl. jax stack) | ✅ 53 files, no issues |
| `pixi run -e test test-cov` (no jax) | ✅ 399 passed; coverage 96.73% ≥ 95% |
| `pixi run -e test-jax test-jax` | ✅ 589 passed; `src/duq/jax` coverage 96.65% ≥ 90% |
| `pixi run -e test-np126 test` | ✅ 399 passed |
| `pixi run -e test-py311 test` / `test-py313 test` | ✅ 399 passed each |
| eq-on-incompatible-dims parity with NumPy layer | ✅ asserted against the actual NumPy-layer result |
| Conformance parity table (numpy layer ↔ jax layer) | ✅ 100+ ops, identical magnitudes + units |
| Fail-loud uncovered primitive | ✅ message names `cholesky` |
| quax pin check | ✅ test asserts installed quax (0.3.6) within `>=0.3.6,<0.5` and that an upper bound exists |

Coverage mechanism: the global 95% gate omits `src/duq/jax` (unimportable without the optional stack); the new pixi `test-jax` task runs the full suite with jax and enforces a dedicated ≥90% gate via `coverage-jax.toml`. The CI `test-jax` job now runs that task.

## Spec deviations (with justification)

1. **`duq.jax.grad`-family wrappers are pytree-style + unit-relabelling, not literal `quaxify(jax.grad(...))`.** The spec asked for "quaxified" wrappers; plain `quaxify(jax.grad(f))` (quaxed-style) breaks whenever `f` *creates* quantities internally and mixes them with traced arguments — the nested quaxify levels split the unit bookkeeping (this is the quax#5 class of sharp edges; unxt ships `unxt.experimental.grad` for exactly this reason). The shipped `duq.jax.grad` reads the static output unit via `jax.eval_shape` (zero flops), differentiates the magnitude, and relabels the gradient with the exact `unit_out/unit_in` — which is what the spec's own test demands ("gradient unit == unit_out/unit_in asserted exactly") and is robust to internally-created quantities. `jacfwd`/`jacrev`/`hessian` get the exact unit from the nested-quantity structure (no eval_shape needed). The raw quaxify composition still works for the arguments-only pattern and is tested; the sharp edge is pinned by a dedicated test and documented in the module docstring.
2. **`select_n`/`pad`/`dynamic_update_slice`/`scatter*` let plain operands adopt the reference unit** instead of raising like `np.where`/`np.pad` with a bare branch. Under jit, `jnp`'s internal literals (`var`'s zero, `pad`'s default 0, `hypot`'s guards) are already tracers when the rule sees them, so a strict check is impossible without breaking those functions; this matches unxt's rules. The stricter scale-invariant-literal check is kept where it is feasible (comparisons).
3. **Extra primitives beyond the spec's list** (`sinh`/`cosh`/`asinh`/`acosh`/`atanh`, `erfc`, `erf_inv`, `square`, `stack`, `split`, `tile`, `sort`, `eq_to`/`lt_to`/`le_to`, `bitcast_convert_type`, `scatter_sub/min/max`): the installed jax (0.10.2) lowers `jnp.stack`/`split`/`tile`/`sort`/`searchsorted`/`copysign` to these newer primitives, and the conformance table requires them.
4. **`jnp.interp` is excluded** from coverage: jax's implementation order-compares against a hard-coded epsilon literal (≈4.9e-32), which is dimensionally unsound at the primitive level. Documented with an `ustrip` workaround.
5. **`cumsum_p` et al.:** this jax has no `cumulative_sum` primitive; `cumsum_p`/`cummax_p`/`cummin_p` are covered, `cumlogsumexp_p` is left to fail loud (dimensionless-only niche).
6. **`Quantity.__hash__ = None`** (like `numpy.ndarray`) since `__eq__` returns arrays; the *unit* stays hashable, which is all the jit cache key needs.

## Also in this PR

- `docs/dev/jax_coverage.md` + generator script, test-enforced sync.
- Meta test extended: `import duq` never imports jax; helpful `ImportError` for `duq.jax` without the extra (runs in the no-jax envs, skips in test-jax).
- `type` pixi env now includes the jax stack so mypy --strict genuinely checks `src/duq/jax` and `tests/jax` (localized `# type: ignore[code]` only inside `duq/jax`, never in public signatures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
